### PR TITLE
feat(seo): finalize SEO metadata and clean URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ firestore-debug-*.log
 
 #Github App credentials
 gha-creds-*.json
+.worktrees/

--- a/2025-03-29.html
+++ b/2025-03-29.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-03-29" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-03-29" rel="canonical"/><meta content="Discover the career highlights and statistics for James Edward Key, the featured New York Yankee for the 2025-03-29 trivia puzzle." name="description"/>
+
+<title>
    James Edward Key Answer - March 29, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 29, 2025: James Edward Key. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - March 29, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-03-29.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 29, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-03-29.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - March 29, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-03-29.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 29, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-03-29.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-03-29"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 29, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of James Edward Key" src="images/answer-2025-03-29.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of James Edward Key" src="images/answer-2025-03-29.webp"/>
+</div>
+<div class="player-info">
+<h2>
         James Edward Key "Jimmy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1987 American League ERA title with a 2.76 ERA.
         </li>
-        <li>
+<li>
          Pitched for two World Series champions: the 1992 Toronto Blue Jays and the 1996 New York Yankees.
         </li>
-        <li>
+<li>
          Finished as the runner-up for the American League Cy Young Award in both 1987 and 1994.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about James Edward Key?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Key was a control pitcher who relied on intelligence and changing speeds rather than overpowering velocity. His primary weapons were a sinking fastball and a sharp slider, which he used to induce weak contact and ground balls. This durable, efficient style allowed him to pitch over 2,500 career innings with a 3.51 ERA and win 186 games.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Key was a control pitcher who relied on intelligence and changing speeds rather than overpowering velocity. His primary weapons were a sinking fastball and a sharp slider, which he used to induce weak contact and ground balls. This durable, efficient style allowed him to pitch over 2,500 career innings with a 3.51 ERA and win 186 games.">
            What made Jimmy Key so consistently effective as a starting pitcher for three different teams?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His most crucial performance was starting and winning the decisive Game 6 of the 1996 World Series against the Atlanta Braves. Pitching on the road, he held a formidable Braves lineup to just one run over 5.1 innings. This victory clinched the Yankees' first World Series title in 18 years.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="His most crucial performance was starting and winning the decisive Game 6 of the 1996 World Series against the Atlanta Braves. Pitching on the road, he held a formidable Braves lineup to just one run over 5.1 innings. This victory clinched the Yankees' first World Series title in 18 years.">
            What was his most significant contribution to the Yankees' 1996 championship run?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring from baseball, Key pursued his passion for golf by returning to his alma mater. He served as the head golf coach for Clemson University for two seasons, from 1999 to 2001. His calm and analytical approach from his pitching days was well-suited for coaching on the golf course.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring from baseball, Key pursued his passion for golf by returning to his alma mater. He served as the head golf coach for Clemson University for two seasons, from 1999 to 2001. His calm and analytical approach from his pitching days was well-suited for coaching on the golf course.">
            Did he have any interesting post-playing career pursuits?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            48.9
           </td>
-          <td>
+<td>
            186
           </td>
-          <td>
+<td>
            117
           </td>
-          <td>
+<td>
            3.51
           </td>
-          <td>
+<td>
            470
           </td>
-          <td>
+<td>
            389
           </td>
-          <td>
+<td>
            10
           </td>
-          <td>
+<td>
            2591.2
           </td>
-          <td>
+<td>
            1538
           </td>
-          <td>
+<td>
            1.229
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-03-29.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-03-29.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998"];
             const warData = [-0.9, 5.0, 4.8, 7.4, 2.0, 1.7, 1.5, 4.3, 3.9, 6.3, 4.4, 0.0, 2.9, 4.6, 1.3];
             const teamsByYear = ["TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "NYY", "NYY", "NYY", "NYY", "BAL", "BAL"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "TOR", "BAL"], "years": ["1986", "1997", "1989", "1992", "1987", "1993", "1995", "1996", "1985", "1991", "1998", "1988", "1984", "1994", "1990"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "James Edward Key", "hints": ["Won the 1987 American League ERA title with a 2.76 ERA.", "Pitched for two World Series champions: the 1992 Toronto Blue Jays and the 1996 New York Yankees.", "Finished as the runner-up for the American League Cy Young Award in both 1987 and 1994."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-03-29.html
+++ b/2025-03-29.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-03-29" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is James Edward Key.">
   <title>
    James Edward Key Answer - March 29, 2025 | Name That Yankee
   </title>

--- a/2025-03-30.html
+++ b/2025-03-30.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-03-30" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-03-30" rel="canonical"/><meta content="Discover the career highlights and statistics for Tony Lazzeri, the featured New York Yankee for the 2025-03-30 trivia puzzle." name="description"/>
+
+<title>
    Tony Lazzeri Answer - March 30, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 30, 2025: Tony Lazzeri. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - March 30, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-03-30.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 30, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-03-30.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - March 30, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-03-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 30, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-03-30.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-03-30"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 30, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tony Lazzeri" src="images/answer-2025-03-30.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tony Lazzeri" src="images/answer-2025-03-30.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tony Lazzeri "Poosh 'Em Up Tony"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Set an American League record by driving in 11 runs in a single game on May 24, 1936.
         </li>
-        <li>
+<li>
          Became the first player in Major League history to hit two grand slams in one game.
         </li>
-        <li>
+<li>
          Earned induction into the National Baseball Hall of Fame in 1991.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Tony Lazzeri?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He was one of the first true power-hitting second basemen, finishing his career with 178 home runs and a .467 slugging percentage. He recorded seven seasons with at least 100 RBIs and maintained a career batting average of .292 over 14 seasons. His offensive production provided a significant boost to the middle of the lineup, which was a rarity for middle infielders of that era.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="He was one of the first true power-hitting second basemen, finishing his career with 178 home runs and a .467 slugging percentage. He recorded seven seasons with at least 100 RBIs and maintained a career batting average of .292 over 14 seasons. His offensive production provided a significant boost to the middle of the lineup, which was a rarity for middle infielders of that era.">
            What was his overall impact on the second base position during the 1920s and 1930s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He appeared in seven World Series with the Yankees, winning five championships between 1927 and 1937. In the 1932 World Series against the Chicago Cubs, he hit two home runs and drove in five runs to help secure a four-game sweep. He was a cornerstone of the legendary 1927 'Murderers' Row' lineup, often batting behind Babe Ruth and Lou Gehrig.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="He appeared in seven World Series with the Yankees, winning five championships between 1927 and 1937. In the 1932 World Series against the Chicago Cubs, he hit two home runs and drove in five runs to help secure a four-game sweep. He was a cornerstone of the legendary 1927 'Murderers' Row' lineup, often batting behind Babe Ruth and Lou Gehrig.">
            How did he contribute to the New York Yankees' success during their numerous World Series appearances?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He played his entire career while managing epilepsy, a condition he kept largely private to avoid the stigma associated with the disorder at the time. He was also a major cultural hero for Italian-Americans, who affectionately gave him the nickname 'Poosh 'Em Up.' This nickname was a call for him to drive runners home and highlighted his role as a pioneer for Italian-American athletes in professional sports.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="He played his entire career while managing epilepsy, a condition he kept largely private to avoid the stigma associated with the disorder at the time. He was also a major cultural hero for Italian-Americans, who affectionately gave him the nickname 'Poosh 'Em Up.' This nickname was a call for him to drive runners home and highlighted his role as a pioneer for Italian-American athletes in professional sports.">
            What personal health challenge and cultural nickname defined his off-field legacy?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            47.6
           </td>
-          <td>
+<td>
            6297
           </td>
-          <td>
+<td>
            1840
           </td>
-          <td>
+<td>
            178
           </td>
-          <td>
+<td>
            .292
           </td>
-          <td>
+<td>
            986
           </td>
-          <td>
+<td>
            1194
           </td>
-          <td>
+<td>
            148
           </td>
-          <td>
+<td>
            .380
           </td>
-          <td>
+<td>
            .467
           </td>
-          <td>
+<td>
            .846
           </td>
-          <td>
+<td>
            121
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-03-30.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-03-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1926", "1927", "1928", "1929", "1930", "1931", "1932", "1933", "1934", "1935", "1936", "1937", "1938", "1939"];
             const warData = [2.9, 6.4, 4.7, 7.8, 3.5, 3.0, 4.4, 3.9, 3.4, 2.7, 2.2, 1.5, 0.7, 0.6];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CHC", "2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYG", "CHC", "NYY", "BRO"], "years": ["1939", "1927", "1932", "1933", "1931", "1926", "1928", "1930", "1935", "1938", "1934", "1936", "1937", "1929"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tony Lazzeri", "hints": ["Set an American League record by driving in 11 runs in a single game on May 24, 1936.", "Became the first player in Major League history to hit two grand slams in one game.", "Earned induction into the National Baseball Hall of Fame in 1991."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-03-30.html
+++ b/2025-03-30.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-03-30" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tony Lazzeri.">
   <title>
    Tony Lazzeri Answer - March 30, 2025 | Name That Yankee
   </title>

--- a/2025-04-01.html
+++ b/2025-04-01.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-01" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Scott Brosius.">
   <title>
    Scott Brosius Answer - April 01, 2025 | Name That Yankee
   </title>

--- a/2025-04-01.html
+++ b/2025-04-01.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-01" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-01" rel="canonical"/><meta content="Discover the career highlights and statistics for Scott Brosius, the featured New York Yankee for the 2025-04-01 trivia puzzle." name="description"/>
+
+<title>
    Scott Brosius Answer - April 01, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 01, 2025: Scott Brosius. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 01, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-01.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 01, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-01.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 01, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-01.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 01, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-01.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-01"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 01, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Scott Brosius" src="images/answer-2025-04-01.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Scott Brosius" src="images/answer-2025-04-01.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Scott Brosius
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the 1998 World Series MVP.
         </li>
-        <li>
+<li>
          Won a Gold Glove Award at third base in 1999.
         </li>
-        <li>
+<li>
          Won three consecutive World Series championships from 1998 to 2000.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            15.7
           </td>
-          <td>
+<td>
            3889
           </td>
-          <td>
+<td>
            1001
           </td>
-          <td>
+<td>
            141
           </td>
-          <td>
+<td>
            .257
           </td>
-          <td>
+<td>
            544
           </td>
-          <td>
+<td>
            531
           </td>
-          <td>
+<td>
            57
           </td>
-          <td>
+<td>
            .323
           </td>
-          <td>
+<td>
            .422
           </td>
-          <td>
+<td>
            .744
           </td>
-          <td>
+<td>
            94
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-01.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-01.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [0.0, 0.3, 0.7, 0.6, 0.6, 5.3, -0.1, 5.3, 1.2, -0.3, 2.1];
             const teamsByYear = ["OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "OAK"], "years": ["1993", "1999", "1998", "1997", "1992", "1995", "2000", "2001", "1996", "1994", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Scott Brosius", "hints": ["Was the 1998 World Series MVP.", "Won a Gold Glove Award at third base in 1999.", "Won three consecutive World Series championships from 1998 to 2000."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-02.html
+++ b/2025-04-02.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-02" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ramiro Mendoza.">
   <title>
    Ramiro Mendoza Answer - April 02, 2025 | Name That Yankee
   </title>

--- a/2025-04-02.html
+++ b/2025-04-02.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-02" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-02" rel="canonical"/><meta content="Discover the career highlights and statistics for Ramiro Mendoza, the featured New York Yankee for the 2025-04-02 trivia puzzle." name="description"/>
+
+<title>
    Ramiro Mendoza Answer - April 02, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 02, 2025: Ramiro Mendoza. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 02, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-02.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 02, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-02.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 02, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-02.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 02, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-02.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-02"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 02, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ramiro Mendoza" src="images/answer-2025-04-02.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ramiro Mendoza" src="images/answer-2025-04-02.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ramiro Mendoza "El Brujo"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won four World Series championships with the New York Yankees.
         </li>
-        <li>
+<li>
          Posted a 10-2 record as both a starter and reliever for the 1998 Yankees.
         </li>
-        <li>
+<li>
          Pitched for both the New York Yankees and Boston Red Sox.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.7
           </td>
-          <td>
+<td>
            59
           </td>
-          <td>
+<td>
            40
           </td>
-          <td>
+<td>
            4.30
           </td>
-          <td>
+<td>
            342
           </td>
-          <td>
+<td>
            62
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            797.0
           </td>
-          <td>
+<td>
            463
           </td>
-          <td>
+<td>
            1.345
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-02.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-02.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005"];
             const warData = [-0.2, 2.5, 2.9, 1.4, 1.6, 2.0, 1.5, -0.5, 0.7, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "BOS", "BOS", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "NYY"], "years": ["1999", "2004", "2000", "2003", "1998", "2001", "2005", "2002", "1996", "1997"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ramiro Mendoza", "hints": ["Won four World Series championships with the New York Yankees.", "Posted a 10-2 record as both a starter and reliever for the 1998 Yankees.", "Pitched for both the New York Yankees and Boston Red Sox."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-03.html
+++ b/2025-04-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Todd Greene.">
   <title>
    Todd Greene Answer - April 03, 2025 | Name That Yankee
   </title>

--- a/2025-04-03.html
+++ b/2025-04-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-03" rel="canonical"/><meta content="Discover the career highlights and statistics for Todd Greene, the featured New York Yankee for the 2025-04-03 trivia puzzle." name="description"/>
+
+<title>
    Todd Greene Answer - April 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 03, 2025: Todd Greene. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Todd Greene" src="images/answer-2025-04-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Todd Greene" src="images/answer-2025-04-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Todd Greene
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a replacement player during the 1994–95 MLB strike.
         </li>
-        <li>
+<li>
          Won the Pacific Coast League MVP award in 1995 after hitting 40 home runs.
         </li>
-        <li>
+<li>
          Hit three home runs in a single game on September 15, 2000.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -2.9
           </td>
-          <td>
+<td>
            1573
           </td>
-          <td>
+<td>
            397
           </td>
-          <td>
+<td>
            71
           </td>
-          <td>
+<td>
            .252
           </td>
-          <td>
+<td>
            181
           </td>
-          <td>
+<td>
            217
           </td>
-          <td>
+<td>
            5
           </td>
-          <td>
+<td>
            .286
           </td>
-          <td>
+<td>
            .444
           </td>
-          <td>
+<td>
            .730
           </td>
-          <td>
+<td>
            83
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006"];
             const warData = [-0.4, 0.8, -0.8, -1.2, -0.4, -0.9, 0.3, 0.0, 0.1, -0.5, 0.3];
             const teamsByYear = ["CAL", "ANA", "ANA", "ANA", "TOR", "NYY", "TEX", "TEX", "COL", "COL", "SFG"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["COL", "SFG", "ANA", "CAL", "TOR", "TEX", "NYY"], "years": ["1996", "1999", "2002", "2004", "2006", "2005", "2001", "2003", "1998", "2000", "1997"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Todd Greene", "hints": ["Was a replacement player during the 1994\u201395 MLB strike.", "Won the Pacific Coast League MVP award in 1995 after hitting 40 home runs.", "Hit three home runs in a single game on September 15, 2000."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-04.html
+++ b/2025-04-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Tony Kubek, the featured New York Yankee for the 2025-04-04 trivia puzzle." name="description"/>
+
+<title>
    Tony Kubek Answer - April 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 04, 2025: Tony Kubek. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tony Kubek" src="images/answer-2025-04-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tony Kubek" src="images/answer-2025-04-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tony Kubek
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the 1957 American League Rookie of the Year.
         </li>
-        <li>
+<li>
          Hit two home runs in Game 3 of the 1957 World Series.
         </li>
-        <li>
+<li>
          Received the Ford C. Frick Award from the Baseball Hall of Fame for broadcasting.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            18.3
           </td>
-          <td>
+<td>
            4167
           </td>
-          <td>
+<td>
            1109
           </td>
-          <td>
+<td>
            57
           </td>
-          <td>
+<td>
            .266
           </td>
-          <td>
+<td>
            522
           </td>
-          <td>
+<td>
            373
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            .303
           </td>
-          <td>
+<td>
            .364
           </td>
-          <td>
+<td>
            .667
           </td>
-          <td>
+<td>
            85
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965"];
             const warData = [2.5, 2.7, 2.3, 3.8, 3.3, 0.8, 2.2, 1.9, -1.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1961", "1959", "1962", "1960", "1958", "1957", "1965", "1964", "1963"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tony Kubek", "hints": ["Was the 1957 American League Rookie of the Year.", "Hit two home runs in Game 3 of the 1957 World Series.", "Received the Ford C. Frick Award from the Baseball Hall of Fame for broadcasting."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-04.html
+++ b/2025-04-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tony Kubek.">
   <title>
    Tony Kubek Answer - April 04, 2025 | Name That Yankee
   </title>

--- a/2025-04-05.html
+++ b/2025-04-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Tim Foli, the featured New York Yankee for the 2025-04-05 trivia puzzle." name="description"/>
+
+<title>
    Tim Foli Answer - April 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 05, 2025: Tim Foli. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tim Foli" src="images/answer-2025-04-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tim Foli" src="images/answer-2025-04-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tim Foli "Crazy Horse"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the first overall pick in the 1968 MLB draft.
         </li>
-        <li>
+<li>
          Won the 1979 World Series with the Pittsburgh Pirates.
         </li>
-        <li>
+<li>
          Led all National League shortstops in fielding percentage in 1974 and 1980.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            5.7
           </td>
-          <td>
+<td>
            6047
           </td>
-          <td>
+<td>
            1515
           </td>
-          <td>
+<td>
            25
           </td>
-          <td>
+<td>
            .251
           </td>
-          <td>
+<td>
            576
           </td>
-          <td>
+<td>
            501
           </td>
-          <td>
+<td>
            81
           </td>
-          <td>
+<td>
            .283
           </td>
-          <td>
+<td>
            .309
           </td>
-          <td>
+<td>
            .593
           </td>
-          <td>
+<td>
            64
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985"];
             const warData = [0.2, 0.1, 1.1, -0.1, 1.9, 0.5, -0.3, -1.3, 0.9, 2.2, 1.5, -0.6, 1.1, -1.1, -0.4, -0.1];
             const teamsByYear = ["NYM", "NYM", "MON", "MON", "MON", "MON", "MON", "2TM", "NYM", "2TM", "PIT", "PIT", "CAL", "CAL", "NYY", "PIT"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PIT", "CAL", "SFG", "MON", "NYM", "NYY"], "years": ["1975", "1976", "1978", "1985", "1984", "1983", "1972", "1970", "1973", "1979", "1981", "1982", "1980", "1977", "1974", "1971"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tim Foli", "hints": ["Was the first overall pick in the 1968 MLB draft.", "Won the 1979 World Series with the Pittsburgh Pirates.", "Led all National League shortstops in fielding percentage in 1974 and 1980."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-05.html
+++ b/2025-04-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tim Foli.">
   <title>
    Tim Foli Answer - April 05, 2025 | Name That Yankee
   </title>

--- a/2025-04-06.html
+++ b/2025-04-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Ralph Terry, the featured New York Yankee for the 2025-04-06 trivia puzzle." name="description"/>
+
+<title>
    Ralph Terry Answer - April 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 06, 2025: Ralph Terry. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ralph Terry" src="images/answer-2025-04-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ralph Terry" src="images/answer-2025-04-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ralph Terry
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Gave up the walk-off home run that ended Game 7 of the 1960 World Series.
         </li>
-        <li>
+<li>
          Was named the 1962 World Series MVP after pitching a Game 7 shutout.
         </li>
-        <li>
+<li>
          Became a professional golfer on the Senior PGA Tour after retiring from baseball.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.8
           </td>
-          <td>
+<td>
            107
           </td>
-          <td>
+<td>
            99
           </td>
-          <td>
+<td>
            3.62
           </td>
-          <td>
+<td>
            338
           </td>
-          <td>
+<td>
            257
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            1849.1
           </td>
-          <td>
+<td>
            1000
           </td>
-          <td>
+<td>
            1.186
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967"];
             const warData = [-0.6, 1.5, 1.3, 1.0, 0.1, 2.2, 4.0, 3.1, -0.5, 1.2, -0.2, 0.1];
             const teamsByYear = ["NYY", "2TM", "KCA", "2TM", "NYY", "NYY", "NYY", "NYY", "NYY", "CLE", "2TM", "NYM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYM", "NYY", "KCA"], "years": ["1967", "1959", "1963", "1956", "1965", "1957", "1958", "1961", "1966", "1964", "1962", "1960"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ralph Terry", "hints": ["Gave up the walk-off home run that ended Game 7 of the 1960 World Series.", "Was named the 1962 World Series MVP after pitching a Game 7 shutout.", "Became a professional golfer on the Senior PGA Tour after retiring from baseball."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-06.html
+++ b/2025-04-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ralph Terry.">
   <title>
    Ralph Terry Answer - April 06, 2025 | Name That Yankee
   </title>

--- a/2025-04-07.html
+++ b/2025-04-07.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-07" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-07" rel="canonical"/><meta content="Discover the career highlights and statistics for Iván Nova, the featured New York Yankee for the 2025-04-07 trivia puzzle." name="description"/>
+
+<title>
    Iván Nova Answer - April 07, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 07, 2025: Iván Nova. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 07, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-07.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 07, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-07.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 07, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-07.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 07, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-07.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-07"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 07, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Iván Nova" src="images/answer-2025-04-07.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Iván Nova" src="images/answer-2025-04-07.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Iván Nova "Supernova"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won Pitcher of the Month awards in both the American League and National League.
         </li>
-        <li>
+<li>
          Became the first foreign pitcher in KBO history to throw a shutout in a debut game.
         </li>
-        <li>
+<li>
          Led the KBO in wins with 20 during the 2022 season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.5
           </td>
-          <td>
+<td>
            90
           </td>
-          <td>
+<td>
            77
           </td>
-          <td>
+<td>
            4.38
           </td>
-          <td>
+<td>
            240
           </td>
-          <td>
+<td>
            227
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            1347.2
           </td>
-          <td>
+<td>
            963
           </td>
-          <td>
+<td>
            1.359
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-07.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-07.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020"];
             const warData = [0.4, 2.6, 0.5, 3.4, -0.7, 0.6, 1.9, 2.0, 1.0, 1.9, -0.5];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "PIT", "PIT", "CHW", "DET"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["DET", "CHW", "PIT", "NYY"], "years": ["2010", "2011", "2018", "2017", "2014", "2013", "2015", "2019", "2020", "2012", "2016"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Iv\u00e1n Nova", "hints": ["Won Pitcher of the Month awards in both the American League and National League.", "Became the first foreign pitcher in KBO history to throw a shutout in a debut game.", "Led the KBO in wins with 20 during the 2022 season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-07.html
+++ b/2025-04-07.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-07" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Iv\u00e1n Nova.">
   <title>
    Iván Nova Answer - April 07, 2025 | Name That Yankee
   </title>

--- a/2025-04-08.html
+++ b/2025-04-08.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-08" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-08" rel="canonical"/><meta content="Discover the career highlights and statistics for Tony Clark, the featured New York Yankee for the 2025-04-08 trivia puzzle." name="description"/>
+
+<title>
    Tony Clark Answer - April 08, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 08, 2025: Tony Clark. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 08, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-08.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 08, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-08.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 08, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-08.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 08, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-08.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-08"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 08, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tony Clark" src="images/answer-2025-04-08.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tony Clark" src="images/answer-2025-04-08.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tony Clark "Tony the Tiger"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Is the first former Major League player to serve as the Executive Director of the MLBPA.
         </li>
-        <li>
+<li>
          Was the second overall pick in the 1990 MLB draft.
         </li>
-        <li>
+<li>
          Hit home runs from both sides of the plate in the same game three times.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            12.3
           </td>
-          <td>
+<td>
            4532
           </td>
-          <td>
+<td>
            1188
           </td>
-          <td>
+<td>
            251
           </td>
-          <td>
+<td>
            .262
           </td>
-          <td>
+<td>
            629
           </td>
-          <td>
+<td>
            824
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            .339
           </td>
-          <td>
+<td>
            .485
           </td>
-          <td>
+<td>
            .824
           </td>
-          <td>
+<td>
            112
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-08.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-08.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009"];
             const warData = [0.2, -0.3, 3.5, 3.3, 2.6, 1.1, 1.7, -1.1, -0.8, 0.2, 3.4, -1.0, 0.0, -0.1, -0.4];
             const teamsByYear = ["DET", "DET", "DET", "DET", "DET", "DET", "DET", "BOS", "NYM", "NYY", "ARI", "ARI", "ARI", "2TM", "ARI"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SDP", "BOS", "NYM", "NYY", "ARI", "DET"], "years": ["2009", "2000", "1997", "1998", "2006", "1996", "1995", "2001", "2008", "2004", "1999", "2003", "2002", "2005", "2007"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tony Clark", "hints": ["Is the first former Major League player to serve as the Executive Director of the MLBPA.", "Was the second overall pick in the 1990 MLB draft.", "Hit home runs from both sides of the plate in the same game three times."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-08.html
+++ b/2025-04-08.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-08" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tony Clark.">
   <title>
    Tony Clark Answer - April 08, 2025 | Name That Yankee
   </title>

--- a/2025-04-09.html
+++ b/2025-04-09.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-09" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-09" rel="canonical"/><meta content="Discover the career highlights and statistics for Tom Tresh, the featured New York Yankee for the 2025-04-09 trivia puzzle." name="description"/>
+
+<title>
    Tom Tresh Answer - April 09, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 09, 2025: Tom Tresh. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 09, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-09.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 09, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-09.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 09, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-09.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 09, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-09.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,193 +42,193 @@
   "datePublished": "2025-04-09"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 09, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tom Tresh" src="images/answer-2025-04-09.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tom Tresh" src="images/answer-2025-04-09.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tom Tresh
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</div>
+<ul>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            21.9
           </td>
-          <td>
+<td>
            4251
           </td>
-          <td>
+<td>
            1041
           </td>
-          <td>
+<td>
            153
           </td>
-          <td>
+<td>
            .245
           </td>
-          <td>
+<td>
            595
           </td>
-          <td>
+<td>
            530
           </td>
-          <td>
+<td>
            45
           </td>
-          <td>
+<td>
            .335
           </td>
-          <td>
+<td>
            .411
           </td>
-          <td>
+<td>
            .746
           </td>
-          <td>
+<td>
            113
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-09.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-09.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969"];
             const warData = [0.0, 4.3, 4.1, 1.8, 3.8, 5.4, -0.1, 2.1, 0.5];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM"];
@@ -348,26 +349,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "DET"], "years": ["1962", "1965", "1963", "1968", "1967", "1964", "1966", "1969", "1961"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tom Tresh", "hints": []}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -378,11 +379,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-09.html
+++ b/2025-04-09.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-09" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tom Tresh.">
   <title>
    Tom Tresh Answer - April 09, 2025 | Name That Yankee
   </title>

--- a/2025-04-11.html
+++ b/2025-04-11.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-11" rel="canonical"/><meta content="Discover the career highlights and statistics for Nick Johnson, the featured New York Yankee for the 2025-04-11 trivia puzzle." name="description"/>
+
+<title>
    Nick Johnson Answer - April 11, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 11, 2025: Nick Johnson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 11, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 11, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-11.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 11, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 11, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-11.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-11"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 11, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Nick Johnson" src="images/answer-2025-04-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Nick Johnson" src="images/answer-2025-04-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Nick Johnson
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Nephew of former MLB shortstop and manager Larry Bowa.
         </li>
-        <li>
+<li>
          Recorded the first cycle in Washington Nationals history on September 23, 2006.
         </li>
-        <li>
+<li>
          Reached base safely in the first 48 games of the 2006 season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.5
           </td>
-          <td>
+<td>
            2698
           </td>
-          <td>
+<td>
            723
           </td>
-          <td>
+<td>
            95
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            430
           </td>
-          <td>
+<td>
            398
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            .399
           </td>
-          <td>
+<td>
            .441
           </td>
-          <td>
+<td>
            .840
           </td>
-          <td>
+<td>
            123
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2001", "2002", "2003", "2004", "2005", "2006", "2008", "2009", "2010", "2012"];
             const warData = [-0.2, 0.8, 2.5, 0.3, 3.6, 5.0, 1.1, 1.5, -0.1, 0.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "MON", "WSN", "WSN", "WSN", "2TM", "NYY", "BAL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MON", "WSN", "FLA", "NYY", "BAL"], "years": ["2003", "2001", "2009", "2002", "2004", "2006", "2008", "2010", "2005", "2012"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Nick Johnson", "hints": ["Nephew of former MLB shortstop and manager Larry Bowa.", "Recorded the first cycle in Washington Nationals history on September 23, 2006.", "Reached base safely in the first 48 games of the 2006 season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-11.html
+++ b/2025-04-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Nick Johnson.">
   <title>
    Nick Johnson Answer - April 11, 2025 | Name That Yankee
   </title>

--- a/2025-04-12.html
+++ b/2025-04-12.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-12" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Santos Alomar.">
   <title>
    Santos Alomar Answer - April 12, 2025 | Name That Yankee
   </title>

--- a/2025-04-12.html
+++ b/2025-04-12.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-12" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-12" rel="canonical"/><meta content="Discover the career highlights and statistics for Santos Alomar, the featured New York Yankee for the 2025-04-12 trivia puzzle." name="description"/>
+
+<title>
    Santos Alomar Answer - April 12, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 12, 2025: Santos Alomar. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 12, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-12.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 12, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-12.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 12, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 12, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-12.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-12"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 12, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Santos Alomar" src="images/answer-2025-04-12.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Santos Alomar" src="images/answer-2025-04-12.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Santos Alomar "Sandy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was an American League All-Star in 1970.
         </li>
-        <li>
+<li>
          Father of Hall of Famer Roberto Alomar and All-Star Sandy Alomar Jr.
         </li>
-        <li>
+<li>
          Coached in the major leagues for 18 seasons after a 15-year playing career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            10.5
           </td>
-          <td>
+<td>
            4760
           </td>
-          <td>
+<td>
            1168
           </td>
-          <td>
+<td>
            13
           </td>
-          <td>
+<td>
            .245
           </td>
-          <td>
+<td>
            558
           </td>
-          <td>
+<td>
            282
           </td>
-          <td>
+<td>
            227
           </td>
-          <td>
+<td>
            .290
           </td>
-          <td>
+<td>
            .288
           </td>
-          <td>
+<td>
            .578
           </td>
-          <td>
+<td>
            69
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-12.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978"];
             const warData = [0.3, 0.8, -0.6, -0.6, -0.9, -0.3, 2.3, 5.2, 1.8, 1.2, 0.6, 1.3, -0.1, -0.3, -0.3];
             const teamsByYear = ["MLN", "MLN", "ATL", "2TM", "CHW", "2TM", "CAL", "CAL", "CAL", "CAL", "2TM", "NYY", "NYY", "TEX", "TEX"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYM", "MLN", "NYY", "TEX", "CHW", "ATL", "CAL"], "years": ["1970", "1977", "1976", "1969", "1975", "1964", "1974", "1973", "1978", "1966", "1967", "1971", "1965", "1968", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Santos Alomar", "hints": ["Was an American League All-Star in 1970.", "Father of Hall of Famer Roberto Alomar and All-Star Sandy Alomar Jr.", "Coached in the major leagues for 18 seasons after a 15-year playing career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-13.html
+++ b/2025-04-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-13" rel="canonical"/><meta content="Discover the career highlights and statistics for Bob Melvin, the featured New York Yankee for the 2025-04-13 trivia puzzle." name="description"/>
+
+<title>
    Bob Melvin Answer - April 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 13, 2025: Bob Melvin. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bob Melvin" src="images/answer-2025-04-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bob Melvin" src="images/answer-2025-04-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bob Melvin "BoMel"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the Manager of the Year award in both the American and National Leagues.
         </li>
-        <li>
+<li>
          Grandfather was the original ball boy for the Washington Senators in 1901.
         </li>
-        <li>
+<li>
          Managed teams to eight postseason appearances with three different franchises.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.5
           </td>
-          <td>
+<td>
            1955
           </td>
-          <td>
+<td>
            456
           </td>
-          <td>
+<td>
            35
           </td>
-          <td>
+<td>
            .233
           </td>
-          <td>
+<td>
            174
           </td>
-          <td>
+<td>
            212
           </td>
-          <td>
+<td>
            4
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            .337
           </td>
-          <td>
+<td>
            .604
           </td>
-          <td>
+<td>
            69
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994"];
             const warData = [-0.5, 1.0, 1.0, 0.9, 0.5, 0.6, -0.2, 0.3, -0.9, -0.4];
             const teamsByYear = ["DET", "SFG", "SFG", "SFG", "BAL", "BAL", "BAL", "KCR", "BOS", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "SFG", "BAL", "KCR", "CHW", "NYY", "DET"], "years": ["1986", "1992", "1993", "1994", "1987", "1988", "1985", "1990", "1989", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bob Melvin", "hints": ["Won the Manager of the Year award in both the American and National Leagues.", "Grandfather was the original ball boy for the Washington Senators in 1901.", "Managed teams to eight postseason appearances with three different franchises."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-13.html
+++ b/2025-04-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bob Melvin.">
   <title>
    Bob Melvin Answer - April 13, 2025 | Name That Yankee
   </title>

--- a/2025-04-14.html
+++ b/2025-04-14.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-14" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Chris Chambliss.">
   <title>
    Chris Chambliss Answer - April 14, 2025 | Name That Yankee
   </title>

--- a/2025-04-14.html
+++ b/2025-04-14.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-14" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-14" rel="canonical"/><meta content="Discover the career highlights and statistics for Chris Chambliss, the featured New York Yankee for the 2025-04-14 trivia puzzle." name="description"/>
+
+<title>
    Chris Chambliss Answer - April 14, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 14, 2025: Chris Chambliss. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 14, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-14.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 14, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-14.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 14, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-14.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 14, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-14.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-14"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 14, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Chris Chambliss" src="images/answer-2025-04-14.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Chris Chambliss" src="images/answer-2025-04-14.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Chris Chambliss "Champ"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit a walk-off home run in the 1976 ALCS to send the New York Yankees to the World Series.
         </li>
-        <li>
+<li>
          Was the 1971 American League Rookie of the Year.
         </li>
-        <li>
+<li>
          Won four World Series championships as a hitting coach for the New York Yankees.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.5
           </td>
-          <td>
+<td>
            7571
           </td>
-          <td>
+<td>
            2109
           </td>
-          <td>
+<td>
            185
           </td>
-          <td>
+<td>
            .279
           </td>
-          <td>
+<td>
            912
           </td>
-          <td>
+<td>
            972
           </td>
-          <td>
+<td>
            40
           </td>
-          <td>
+<td>
            .334
           </td>
-          <td>
+<td>
            .415
           </td>
-          <td>
+<td>
            .749
           </td>
-          <td>
+<td>
            109
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-14.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-14.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1988"];
             const warData = [0.5, 2.0, 1.6, 0.7, 3.3, 4.1, 2.4, 3.2, 1.8, 2.8, 1.3, 2.8, 0.8, -0.1, 0.3, 0.3, 0.0];
             const teamsByYear = ["CLE", "CLE", "CLE", "2TM", "NYY", "NYY", "NYY", "NYY", "NYY", "ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CLE", "ATL"], "years": ["1986", "1975", "1981", "1976", "1974", "1971", "1972", "1978", "1988", "1979", "1980", "1984", "1977", "1983", "1982", "1973", "1985"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Chris Chambliss", "hints": ["Hit a walk-off home run in the 1976 ALCS to send the New York Yankees to the World Series.", "Was the 1971 American League Rookie of the Year.", "Won four World Series championships as a hitting coach for the New York Yankees."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-15.html
+++ b/2025-04-15.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-15" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is John Mayberry.">
   <title>
    John Mayberry Answer - April 15, 2025 | Name That Yankee
   </title>

--- a/2025-04-15.html
+++ b/2025-04-15.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-15" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-15" rel="canonical"/><meta content="Discover the career highlights and statistics for John Mayberry, the featured New York Yankee for the 2025-04-15 trivia puzzle." name="description"/>
+
+<title>
    John Mayberry Answer - April 15, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 15, 2025: John Mayberry. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 15, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-15.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 15, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-15.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 15, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-15.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 15, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-15.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-15"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 15, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of John Mayberry" src="images/answer-2025-04-15.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of John Mayberry" src="images/answer-2025-04-15.webp"/>
+</div>
+<div class="player-info">
+<h2>
         John Mayberry "Big John"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Finished second in the 1975 American League MVP voting.
         </li>
-        <li>
+<li>
          Was a two-time American League All-Star.
         </li>
-        <li>
+<li>
          Father of John Mayberry Jr., who played nine seasons in MLB.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            25.0
           </td>
-          <td>
+<td>
            5447
           </td>
-          <td>
+<td>
            1379
           </td>
-          <td>
+<td>
            255
           </td>
-          <td>
+<td>
            .253
           </td>
-          <td>
+<td>
            733
           </td>
-          <td>
+<td>
            879
           </td>
-          <td>
+<td>
            20
           </td>
-          <td>
+<td>
            .360
           </td>
-          <td>
+<td>
            .439
           </td>
-          <td>
+<td>
            .799
           </td>
-          <td>
+<td>
            123
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-15.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-15.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982"];
             const warData = [-0.2, -0.1, 0.6, 0.1, 4.9, 5.2, 1.9, 7.2, 1.4, 0.8, -0.5, 1.7, 1.1, 1.1, -0.3];
             const teamsByYear = ["HOU", "HOU", "HOU", "HOU", "KCR", "KCR", "KCR", "KCR", "KCR", "KCR", "TOR", "TOR", "TOR", "TOR", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "HOU", "TOR", "KCR"], "years": ["1981", "1975", "1968", "1977", "1980", "1974", "1973", "1979", "1982", "1978", "1971", "1976", "1970", "1972", "1969"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "John Mayberry", "hints": ["Finished second in the 1975 American League MVP voting.", "Was a two-time American League All-Star.", "Father of John Mayberry Jr., who played nine seasons in MLB."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-17.html
+++ b/2025-04-17.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-17" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-17" rel="canonical"/><meta content="Discover the career highlights and statistics for Ji-Man Choi, the featured New York Yankee for the 2025-04-17 trivia puzzle." name="description"/>
+
+<title>
    Ji-Man Choi Answer - April 17, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 17, 2025: Ji-Man Choi. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 17, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-17.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 17, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-17.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 17, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-17.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 17, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-17.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-17"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 17, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ji-Man Choi" src="images/answer-2025-04-17.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ji-Man Choi" src="images/answer-2025-04-17.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ji-Man Choi
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the first Korean-born position player to play for the New York Yankees.
         </li>
-        <li>
+<li>
          Pitched in MLB games as both a right-handed and left-handed pitcher.
         </li>
-        <li>
+<li>
          Hit a home run in the 2020 World Series.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.8
           </td>
-          <td>
+<td>
            1567
           </td>
-          <td>
+<td>
            367
           </td>
-          <td>
+<td>
            67
           </td>
-          <td>
+<td>
            .234
           </td>
-          <td>
+<td>
            190
           </td>
-          <td>
+<td>
            238
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            .338
           </td>
-          <td>
+<td>
            .426
           </td>
-          <td>
+<td>
            .764
           </td>
-          <td>
+<td>
            112
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-17.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-17.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023"];
             const warData = [-0.6, 0.1, 1.1, 2.1, 0.4, 1.0, 1.2, -0.4];
             const teamsByYear = ["LAA", "NYY", "2TM", "TBR", "TBR", "TBR", "TBR", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PIT", "SDP", "NYY", "MIL", "LAA", "TBR"], "years": ["2019", "2017", "2022", "2023", "2020", "2021", "2018", "2016"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ji-Man Choi", "hints": ["Was the first Korean-born position player to play for the New York Yankees.", "Pitched in MLB games as both a right-handed and left-handed pitcher.", "Hit a home run in the 2020 World Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-17.html
+++ b/2025-04-17.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-17" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ji-Man Choi.">
   <title>
    Ji-Man Choi Answer - April 17, 2025 | Name That Yankee
   </title>

--- a/2025-04-18.html
+++ b/2025-04-18.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-18" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Dioner Navarro.">
   <title>
    Dioner Navarro Answer - April 18, 2025 | Name That Yankee
   </title>

--- a/2025-04-18.html
+++ b/2025-04-18.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-18" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-18" rel="canonical"/><meta content="Discover the career highlights and statistics for Dioner Navarro, the featured New York Yankee for the 2025-04-18 trivia puzzle." name="description"/>
+
+<title>
    Dioner Navarro Answer - April 18, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 18, 2025: Dioner Navarro. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 18, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-18.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 18, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-18.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 18, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-18.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 18, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-18.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-18"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 18, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Dioner Navarro" src="images/answer-2025-04-18.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Dioner Navarro" src="images/answer-2025-04-18.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Dioner Navarro
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was named an American League All-Star in 2008.
         </li>
-        <li>
+<li>
          Was traded twice on the same day in 2005.
         </li>
-        <li>
+<li>
          Served as the personal catcher for knuckleball pitcher R.A. Dickey.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            7.0
           </td>
-          <td>
+<td>
            3207
           </td>
-          <td>
+<td>
            802
           </td>
-          <td>
+<td>
            77
           </td>
-          <td>
+<td>
            .250
           </td>
-          <td>
+<td>
            322
           </td>
-          <td>
+<td>
            367
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            .309
           </td>
-          <td>
+<td>
            .370
           </td>
-          <td>
+<td>
            .679
           </td>
-          <td>
+<td>
            83
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-18.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-18.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016"];
             const warData = [0.1, 0.7, 0.0, 0.3, 2.0, -0.4, 0.0, -0.1, 0.3, 1.9, 2.5, 0.7, -1.0];
             const teamsByYear = ["NYY", "LAD", "2TM", "TBD", "TBR", "TBR", "TBR", "LAD", "CIN", "CHC", "TOR", "TOR", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TBR", "TBD", "CIN", "TOR", "CHW", "NYY", "CHC", "LAD"], "years": ["2013", "2015", "2005", "2011", "2006", "2014", "2004", "2012", "2016", "2009", "2008", "2007", "2010"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Dioner Navarro", "hints": ["Was named an American League All-Star in 2008.", "Was traded twice on the same day in 2005.", "Served as the personal catcher for knuckleball pitcher R.A. Dickey."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-19.html
+++ b/2025-04-19.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Richard Monteleone, the featured New York Yankee for the 2025-04-19 trivia puzzle." name="description"/>
+
+<title>
    Richard Monteleone Answer - April 19, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 19, 2025: Richard Monteleone. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 19, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 19, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-19.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 19, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 19, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-19.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-19"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 19, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Richard Monteleone" src="images/answer-2025-04-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Richard Monteleone" src="images/answer-2025-04-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Richard Monteleone
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a first-round draft pick (20th overall) by the Detroit Tigers in 1982.
         </li>
-        <li>
+<li>
          Pitched one season for the Chunichi Dragons of Nippon Professional Baseball.
         </li>
-        <li>
+<li>
          Served as the major league bullpen coach for the New York Yankees and Miami Marlins.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.6
           </td>
-          <td>
+<td>
            24
           </td>
-          <td>
+<td>
            17
           </td>
-          <td>
+<td>
            3.87
           </td>
-          <td>
+<td>
            210
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            353.1
           </td>
-          <td>
+<td>
            212
           </td>
-          <td>
+<td>
            1.310
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996"];
             const warData = [0.0, 0.4, 0.5, -0.1, 0.0, 1.5, -0.4, 0.4, 0.3, -0.1];
             const teamsByYear = ["SEA", "CAL", "CAL", "NYY", "NYY", "NYY", "NYY", "SFG", "CAL", "CAL"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CAL", "SFG", "SEA"], "years": ["1995", "1996", "1989", "1993", "1992", "1991", "1987", "1990", "1988", "1994"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Richard Monteleone", "hints": ["Was a first-round draft pick (20th overall) by the Detroit Tigers in 1982.", "Pitched one season for the Chunichi Dragons of Nippon Professional Baseball.", "Served as the major league bullpen coach for the New York Yankees and Miami Marlins."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-19.html
+++ b/2025-04-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Richard Monteleone.">
   <title>
    Richard Monteleone Answer - April 19, 2025 | Name That Yankee
   </title>

--- a/2025-04-20.html
+++ b/2025-04-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is David Robertson.">
   <title>
    David Robertson Answer - April 20, 2025 | Name That Yankee
   </title>

--- a/2025-04-20.html
+++ b/2025-04-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-20" rel="canonical"/><meta content="Discover the career highlights and statistics for David Robertson, the featured New York Yankee for the 2025-04-20 trivia puzzle." name="description"/>
+
+<title>
    David Robertson Answer - April 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 20, 2025: David Robertson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of David Robertson" src="images/answer-2025-04-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of David Robertson" src="images/answer-2025-04-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         David Robertson "D-Rob"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a World Series championship 14 years apart in 2009 and 2023.
         </li>
-        <li>
+<li>
          Won silver medals for Team USA in both the Olympics and the World Baseball Classic.
         </li>
-        <li>
+<li>
          Was selected to the American League All-Star team in 2011.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            21.9
           </td>
-          <td>
+<td>
            68
           </td>
-          <td>
+<td>
            46
           </td>
-          <td>
+<td>
            2.93
           </td>
-          <td>
+<td>
            881
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            179
           </td>
-          <td>
+<td>
            894.1
           </td>
-          <td>
+<td>
            1176
           </td>
-          <td>
+<td>
            1.162
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2021", "2022", "2023", "2024", "2025"];
             const warData = [0.1, 0.7, 0.8, 3.7, 1.7, 2.4, 1.2, 0.5, 1.2, 2.9, 0.7, 0.0, -0.1, 2.7, 1.7, 1.7, 0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CHW", "CHW", "2TM", "NYY", "PHI", "TBR", "2TM", "2TM", "TEX", "PHI"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHC", "MIA", "NYM", "TBR", "CHW", "PHI", "NYY", "TEX"], "years": ["2019", "2025", "2014", "2021", "2022", "2010", "2018", "2017", "2013", "2012", "2016", "2009", "2015", "2008", "2024", "2023", "2011"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "David Robertson", "hints": ["Won a World Series championship 14 years apart in 2009 and 2023.", "Won silver medals for Team USA in both the Olympics and the World Baseball Classic.", "Was selected to the American League All-Star team in 2011."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-21.html
+++ b/2025-04-21.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-21" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-21" rel="canonical"/><meta content="Discover the career highlights and statistics for Enrique Wilson, the featured New York Yankee for the 2025-04-21 trivia puzzle." name="description"/>
+
+<title>
    Enrique Wilson Answer - April 21, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 21, 2025: Enrique Wilson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 21, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-21.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 21, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-21.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 21, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-21.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 21, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-21.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-21"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 21, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Enrique Wilson" src="images/answer-2025-04-21.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Enrique Wilson" src="images/answer-2025-04-21.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Enrique Wilson
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Batted .440 (11-for-25) against pitcher Pedro Martinez.
         </li>
-        <li>
+<li>
          Played every infield position during an MLB career.
         </li>
-        <li>
+<li>
          Hit 22 home runs and recorded 141 RBIs in 555 career games.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -5.2
           </td>
-          <td>
+<td>
            1406
           </td>
-          <td>
+<td>
            343
           </td>
-          <td>
+<td>
            22
           </td>
-          <td>
+<td>
            .244
           </td>
-          <td>
+<td>
            155
           </td>
-          <td>
+<td>
            141
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            .288
           </td>
-          <td>
+<td>
            .350
           </td>
-          <td>
+<td>
            .638
           </td>
-          <td>
+<td>
            64
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-21.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-21.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005"];
             const warData = [0.0, 0.3, -0.7, -0.1, -1.1, -0.9, -0.4, -2.1, -0.3];
             const teamsByYear = ["CLE", "CLE", "CLE", "2TM", "2TM", "NYY", "NYY", "NYY", "CHC"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "PIT", "CHC", "NYY"], "years": ["1997", "1999", "2004", "2002", "2003", "1998", "2000", "2001", "2005"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Enrique Wilson", "hints": ["Batted .440 (11-for-25) against pitcher Pedro Martinez.", "Played every infield position during an MLB career.", "Hit 22 home runs and recorded 141 RBIs in 555 career games."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-21.html
+++ b/2025-04-21.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-21" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Enrique Wilson.">
   <title>
    Enrique Wilson Answer - April 21, 2025 | Name That Yankee
   </title>

--- a/2025-04-22.html
+++ b/2025-04-22.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-22" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Fred Stanley.">
   <title>
    Fred Stanley Answer - April 22, 2025 | Name That Yankee
   </title>

--- a/2025-04-22.html
+++ b/2025-04-22.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-22" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-22" rel="canonical"/><meta content="Discover the career highlights and statistics for Fred Stanley, the featured New York Yankee for the 2025-04-22 trivia puzzle." name="description"/>
+
+<title>
    Fred Stanley Answer - April 22, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 22, 2025: Fred Stanley. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 22, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-22.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 22, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-22.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 22, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-22.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 22, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-22.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-22"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 22, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Fred Stanley" src="images/answer-2025-04-22.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Fred Stanley" src="images/answer-2025-04-22.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Fred Stanley "Chicken"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won two World Series championships with the New York Yankees.
         </li>
-        <li>
+<li>
          Was the last active player from the original Seattle Pilots franchise.
         </li>
-        <li>
+<li>
          Hit 10 home runs over a 14-season Major League career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            52.6
           </td>
-          <td>
+<td>
            8757
           </td>
-          <td>
+<td>
            2490
           </td>
-          <td>
+<td>
            493
           </td>
-          <td>
+<td>
            .284
           </td>
-          <td>
+<td>
            1349
           </td>
-          <td>
+<td>
            1550
           </td>
-          <td>
+<td>
            72
           </td>
-          <td>
+<td>
            .377
           </td>
-          <td>
+<td>
            .509
           </td>
-          <td>
+<td>
            .886
           </td>
-          <td>
+<td>
            134
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-22.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-22.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004"];
             const warData = [-0.1, 1.4, 6.2, 6.6, 5.2, 3.4, 5.2, 4.2, 4.6, 1.4, 1.7, 0.2, 2.9, 4.0, 0.2, 3.7, 2.1, 0.4, -0.6];
             const teamsByYear = ["TOR", "TOR", "TOR", "TOR", "TOR", "SDP", "SDP", "2TM", "ATL", "ATL", "ATL", "ATL", "TBD", "TBD", "TBD", "2TM", "CHC", "LAD", "TBD"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHC", "LAD", "ATL", "TOR", "TBD", "SDP"], "years": ["1988", "1990", "1992", "1993", "1995", "1996", "1989", "1987", "1999", "1997", "1991", "2000", "2002", "2001", "1994", "1986", "2003", "2004", "1998"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Fred Stanley", "hints": ["Won two World Series championships with the New York Yankees.", "Was the last active player from the original Seattle Pilots franchise.", "Hit 10 home runs over a 14-season Major League career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-23.html
+++ b/2025-04-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Joe Gordon.">
   <title>
    Joe Gordon Answer - April 23, 2025 | Name That Yankee
   </title>

--- a/2025-04-23.html
+++ b/2025-04-23.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Joe Gordon, the featured New York Yankee for the 2025-04-23 trivia puzzle." name="description"/>
+
+<title>
    Joe Gordon Answer - April 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 23, 2025: Joe Gordon. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Joe Gordon" src="images/answer-2025-04-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Joe Gordon" src="images/answer-2025-04-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Joe Gordon "Flash"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1942 American League MVP Award.
         </li>
-        <li>
+<li>
          Was traded for another manager mid-season in 1960.
         </li>
-        <li>
+<li>
          Was elected to the Baseball Hall of Fame in 2009 by the Veterans Committee.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            55.6
           </td>
-          <td>
+<td>
            5707
           </td>
-          <td>
+<td>
            1530
           </td>
-          <td>
+<td>
            253
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            914
           </td>
-          <td>
+<td>
            975
           </td>
-          <td>
+<td>
            89
           </td>
-          <td>
+<td>
            .357
           </td>
-          <td>
+<td>
            .466
           </td>
-          <td>
+<td>
            .822
           </td>
-          <td>
+<td>
            120
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1938", "1939", "1940", "1941", "1942", "1943", "1946", "1947", "1948", "1949", "1950"];
             const warData = [3.4, 6.2, 6.0, 5.2, 7.7, 6.5, 1.5, 6.6, 6.5, 3.9, 2.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CLE", "CLE", "CLE", "CLE"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYY"], "years": ["1942", "1938", "1941", "1950", "1939", "1946", "1940", "1943", "1949", "1947", "1948"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Joe Gordon", "hints": ["Won the 1942 American League MVP Award.", "Was traded for another manager mid-season in 1960.", "Was elected to the Baseball Hall of Fame in 2009 by the Veterans Committee."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-25.html
+++ b/2025-04-25.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-25" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-25" rel="canonical"/><meta content="Discover the career highlights and statistics for Ted Lilly, the featured New York Yankee for the 2025-04-25 trivia puzzle." name="description"/>
+
+<title>
    Ted Lilly Answer - April 25, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 25, 2025: Ted Lilly. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 25, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-25.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 25, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-25.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 25, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-25.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 25, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-25.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-25"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 25, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ted Lilly" src="images/answer-2025-04-25.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ted Lilly" src="images/answer-2025-04-25.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ted Lilly
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a two-time All-Star.
         </li>
-        <li>
+<li>
          Represented the United States in the 2006 World Baseball Classic.
         </li>
-        <li>
+<li>
          Came within one out of a no-hitter on June 13, 2010.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.1
           </td>
-          <td>
+<td>
            130
           </td>
-          <td>
+<td>
            113
           </td>
-          <td>
+<td>
            4.14
           </td>
-          <td>
+<td>
            356
           </td>
-          <td>
+<td>
            331
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            1982.2
           </td>
-          <td>
+<td>
            1681
           </td>
-          <td>
+<td>
            1.255
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-25.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-25.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013"];
             const warData = [-0.4, 0.0, 0.1, 2.4, 2.3, 4.2, 0.2, 1.6, 4.1, 4.0, 5.0, 4.0, 1.6, 0.6, -0.4];
             const teamsByYear = ["MON", "NYY", "NYY", "2TM", "OAK", "TOR", "TOR", "TOR", "CHC", "CHC", "CHC", "2TM", "LAD", "LAD", "LAD"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHC", "MON", "TOR", "LAD", "OAK", "NYY"], "years": ["2001", "2002", "2008", "2010", "2006", "2000", "2003", "2012", "2009", "2004", "2013", "2011", "1999", "2007", "2005"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ted Lilly", "hints": ["Was a two-time All-Star.", "Represented the United States in the 2006 World Baseball Classic.", "Came within one out of a no-hitter on June 13, 2010."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-25.html
+++ b/2025-04-25.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-25" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ted Lilly.">
   <title>
    Ted Lilly Answer - April 25, 2025 | Name That Yankee
   </title>

--- a/2025-04-27.html
+++ b/2025-04-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Bill Dickey, the featured New York Yankee for the 2025-04-27 trivia puzzle." name="description"/>
+
+<title>
    Bill Dickey Answer - April 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 27, 2025: Bill Dickey. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bill Dickey" src="images/answer-2025-04-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bill Dickey" src="images/answer-2025-04-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bill Dickey
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Caught 100 or more games in 13 consecutive seasons.
         </li>
-        <li>
+<li>
          Won a World Series as a player and as a manager with the same franchise.
         </li>
-        <li>
+<li>
          Younger brother, George, was also a major league catcher.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            56.4
           </td>
-          <td>
+<td>
            6300
           </td>
-          <td>
+<td>
            1969
           </td>
-          <td>
+<td>
            202
           </td>
-          <td>
+<td>
            .313
           </td>
-          <td>
+<td>
            930
           </td>
-          <td>
+<td>
            1209
           </td>
-          <td>
+<td>
            36
           </td>
-          <td>
+<td>
            .382
           </td>
-          <td>
+<td>
            .486
           </td>
-          <td>
+<td>
            .868
           </td>
-          <td>
+<td>
            127
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1928", "1929", "1930", "1931", "1932", "1933", "1934", "1935", "1936", "1937", "1938", "1939", "1940", "1941", "1942", "1943", "1946"];
             const warData = [0.0, 3.5, 2.4, 4.1, 2.3, 4.4, 3.5, 3.0, 5.9, 6.6, 5.0, 5.4, 1.2, 2.3, 1.7, 4.1, 1.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1935", "1937", "1939", "1940", "1934", "1931", "1930", "1928", "1929", "1933", "1936", "1942", "1943", "1941", "1946", "1938", "1932"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bill Dickey", "hints": ["Caught 100 or more games in 13 consecutive seasons.", "Won a World Series as a player and as a manager with the same franchise.", "Younger brother, George, was also a major league catcher."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-27.html
+++ b/2025-04-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bill Dickey.">
   <title>
    Bill Dickey Answer - April 27, 2025 | Name That Yankee
   </title>

--- a/2025-04-28.html
+++ b/2025-04-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Brian Roberts.">
   <title>
    Brian Roberts Answer - April 28, 2025 | Name That Yankee
   </title>

--- a/2025-04-28.html
+++ b/2025-04-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Brian Roberts, the featured New York Yankee for the 2025-04-28 trivia puzzle." name="description"/>
+
+<title>
    Brian Roberts Answer - April 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 28, 2025: Brian Roberts. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Brian Roberts" src="images/answer-2025-04-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Brian Roberts" src="images/answer-2025-04-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Brian Roberts "B-Rob"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Led the major leagues with 56 doubles in 2009.
         </li>
-        <li>
+<li>
          Was a two-time American League All-Star.
         </li>
-        <li>
+<li>
          Father was the head baseball coach at the University of North Carolina for 21 seasons.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            29.5
           </td>
-          <td>
+<td>
            5531
           </td>
-          <td>
+<td>
            1527
           </td>
-          <td>
+<td>
            97
           </td>
-          <td>
+<td>
            .276
           </td>
-          <td>
+<td>
            850
           </td>
-          <td>
+<td>
            542
           </td>
-          <td>
+<td>
            285
           </td>
-          <td>
+<td>
            .347
           </td>
-          <td>
+<td>
            .409
           </td>
-          <td>
+<td>
            .756
           </td>
-          <td>
+<td>
            101
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014"];
             const warData = [-0.3, 0.2, 2.7, 2.4, 7.3, 3.3, 4.2, 5.2, 3.0, 1.2, 0.1, -1.1, 0.6, 0.7];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "BAL"], "years": ["2014", "2004", "2009", "2006", "2001", "2013", "2008", "2003", "2012", "2011", "2005", "2007", "2002", "2010"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Brian Roberts", "hints": ["Led the major leagues with 56 doubles in 2009.", "Was a two-time American League All-Star.", "Father was the head baseball coach at the University of North Carolina for 21 seasons."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-29.html
+++ b/2025-04-29.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-29" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Sidney Ponson.">
   <title>
    Sidney Ponson Answer - April 29, 2025 | Name That Yankee
   </title>

--- a/2025-04-29.html
+++ b/2025-04-29.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-29" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-29" rel="canonical"/><meta content="Discover the career highlights and statistics for Sidney Ponson, the featured New York Yankee for the 2025-04-29 trivia puzzle." name="description"/>
+
+<title>
    Sidney Ponson Answer - April 29, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 29, 2025: Sidney Ponson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 29, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-29.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 29, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-29.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 29, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-29.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 29, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-29.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-04-29"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 29, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Sidney Ponson" src="images/answer-2025-04-29.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Sidney Ponson" src="images/answer-2025-04-29.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Sidney Ponson "The Count"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was knighted in his native country of Aruba in 2003.
         </li>
-        <li>
+<li>
          Was an American League All-Star in 2003.
         </li>
-        <li>
+<li>
          Led the American League in losses in 2004.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.1
           </td>
-          <td>
+<td>
            91
           </td>
-          <td>
+<td>
            113
           </td>
-          <td>
+<td>
            5.03
           </td>
-          <td>
+<td>
            298
           </td>
-          <td>
+<td>
            278
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            1760.1
           </td>
-          <td>
+<td>
            1031
           </td>
-          <td>
+<td>
            1.484
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-29.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-29.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009"];
             const warData = [0.9, 1.8, 2.7, 0.6, 2.5, 4.5, 1.4, -1.3, -0.9, -0.6, 0.3, -0.7];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "2TM", "BAL", "BAL", "2TM", "MIN", "2TM", "KCR"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "MIN", "STL", "BAL", "KCR", "TEX", "SFG"], "years": ["2009", "2002", "2000", "2007", "2004", "1999", "1998", "2008", "2001", "2005", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Sidney Ponson", "hints": ["Was knighted in his native country of Aruba in 2003.", "Was an American League All-Star in 2003.", "Led the American League in losses in 2004."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-30.html
+++ b/2025-04-30.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-04-30" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-04-30" rel="canonical"/><meta content="Discover the career highlights and statistics for Gus Triandos, the featured New York Yankee for the 2025-04-30 trivia puzzle." name="description"/>
+
+<title>
    Gus Triandos Answer - April 30, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on April 30, 2025: Gus Triandos. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - April 30, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-04-30.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - April 30, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-04-30.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - April 30, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-04-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 30, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-04-30.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-04-30"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for April 30, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Gus Triandos" src="images/answer-2025-04-30.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Gus Triandos" src="images/answer-2025-04-30.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Gus Triandos "The Big Bear"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the first American League catcher to hit 30 home runs in a season.
         </li>
-        <li>
+<li>
          Set a single-season record with 28 passed balls in 1959.
         </li>
-        <li>
+<li>
          Was a four-time All-Star selection.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.1
           </td>
-          <td>
+<td>
            3907
           </td>
-          <td>
+<td>
            954
           </td>
-          <td>
+<td>
            167
           </td>
-          <td>
+<td>
            .244
           </td>
-          <td>
+<td>
            389
           </td>
-          <td>
+<td>
            608
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            .322
           </td>
-          <td>
+<td>
            .413
           </td>
-          <td>
+<td>
            .735
           </td>
-          <td>
+<td>
            103
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-04-30.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-04-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1953", "1954", "1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965"];
             const warData = [-0.3, 0.0, 1.1, 3.1, 2.9, 3.0, 1.4, 1.5, 1.2, -1.0, 0.9, 1.2, -0.9];
             const teamsByYear = ["NYY", "NYY", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "DET", "PHI", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BAL", "NYY", "HOU", "DET", "PHI"], "years": ["1957", "1959", "1955", "1963", "1965", "1958", "1953", "1956", "1964", "1962", "1960", "1954", "1961"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Gus Triandos", "hints": ["Was the first American League catcher to hit 30 home runs in a season.", "Set a single-season record with 28 passed balls in 1959.", "Was a four-time All-Star selection."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-04-30.html
+++ b/2025-04-30.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-04-30" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Gus Triandos.">
   <title>
    Gus Triandos Answer - April 30, 2025 | Name That Yankee
   </title>

--- a/2025-05-02.html
+++ b/2025-05-02.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-02" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-02" rel="canonical"/><meta content="Discover the career highlights and statistics for Shane Spencer, the featured New York Yankee for the 2025-05-02 trivia puzzle." name="description"/>
+
+<title>
    Shane Spencer Answer - May 02, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 02, 2025: Shane Spencer. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 02, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-02.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 02, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-02.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 02, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-02.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 02, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-02.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-02"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 02, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Shane Spencer" src="images/answer-2025-05-02.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Shane Spencer" src="images/answer-2025-05-02.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Shane Spencer
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit 10 home runs in 67 at-bats during September of the 1998 season.
         </li>
-        <li>
+<li>
          Tied a major league record with three grand slams in a single month.
         </li>
-        <li>
+<li>
          Won three consecutive World Series championships from 1998 to 2000.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.9
           </td>
-          <td>
+<td>
            1671
           </td>
-          <td>
+<td>
            438
           </td>
-          <td>
+<td>
            59
           </td>
-          <td>
+<td>
            .262
           </td>
-          <td>
+<td>
            208
           </td>
-          <td>
+<td>
            242
           </td>
-          <td>
+<td>
            13
           </td>
-          <td>
+<td>
            .326
           </td>
-          <td>
+<td>
            .428
           </td>
-          <td>
+<td>
            .754
           </td>
-          <td>
+<td>
            95
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-02.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-02.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1998", "1999", "2000", "2001", "2002", "2003", "2004"];
             const warData = [1.1, 0.3, 0.6, 2.1, -0.1, 0.6, 0.4];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "NYM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "TEX", "NYM", "NYY"], "years": ["1999", "1998", "2004", "2003", "2002", "2001", "2000"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Shane Spencer", "hints": ["Hit 10 home runs in 67 at-bats during September of the 1998 season.", "Tied a major league record with three grand slams in a single month.", "Won three consecutive World Series championships from 1998 to 2000."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-02.html
+++ b/2025-05-02.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-02" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Shane Spencer.">
   <title>
    Shane Spencer Answer - May 02, 2025 | Name That Yankee
   </title>

--- a/2025-05-03.html
+++ b/2025-05-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Reid Brignac.">
   <title>
    Reid Brignac Answer - May 03, 2025 | Name That Yankee
   </title>

--- a/2025-05-03.html
+++ b/2025-05-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-03" rel="canonical"/><meta content="Discover the career highlights and statistics for Reid Brignac, the featured New York Yankee for the 2025-05-03 trivia puzzle." name="description"/>
+
+<title>
    Reid Brignac Answer - May 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 03, 2025: Reid Brignac. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Reid Brignac" src="images/answer-2025-05-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Reid Brignac" src="images/answer-2025-05-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Reid Brignac
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a second-round pick in the 2004 MLB Draft.
         </li>
-        <li>
+<li>
          Hit a first career grand slam on September 25, 2010.
         </li>
-        <li>
+<li>
          Played for six different MLB teams during a nine-season career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -1.2
           </td>
-          <td>
+<td>
            886
           </td>
-          <td>
+<td>
            194
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            .219
           </td>
-          <td>
+<td>
            83
           </td>
-          <td>
+<td>
            84
           </td>
-          <td>
+<td>
            9
           </td>
-          <td>
+<td>
            .264
           </td>
-          <td>
+<td>
            .309
           </td>
-          <td>
+<td>
            .573
           </td>
-          <td>
+<td>
            59
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016"];
             const warData = [-0.4, 0.2, 2.5, -1.3, -0.3, -1.0, -0.6, -0.2, -0.1];
             const teamsByYear = ["TBR", "TBR", "TBR", "TBR", "TBR", "2TM", "PHI", "MIA", "ATL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PHI", "TBR", "NYY", "ATL", "MIA", "COL"], "years": ["2009", "2014", "2015", "2013", "2012", "2010", "2008", "2016", "2011"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Reid Brignac", "hints": ["Was a second-round pick in the 2004 MLB Draft.", "Hit a first career grand slam on September 25, 2010.", "Played for six different MLB teams during a nine-season career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-04.html
+++ b/2025-05-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Wade Boggs.">
   <title>
    Wade Boggs Answer - May 04, 2025 | Name That Yankee
   </title>

--- a/2025-05-04.html
+++ b/2025-05-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Wade Boggs, the featured New York Yankee for the 2025-05-04 trivia puzzle." name="description"/>
+
+<title>
    Wade Boggs Answer - May 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 04, 2025: Wade Boggs. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Wade Boggs" src="images/answer-2025-05-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Wade Boggs" src="images/answer-2025-05-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Wade Boggs "Chicken Man"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Recorded seven consecutive seasons with 200 or more hits.
         </li>
-        <li>
+<li>
          Hit a home run for the 3,000th career hit.
         </li>
-        <li>
+<li>
          Was the first player to have a number retired by the Tampa Bay Devil Rays.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            91.4
           </td>
-          <td>
+<td>
            9180
           </td>
-          <td>
+<td>
            3010
           </td>
-          <td>
+<td>
            118
           </td>
-          <td>
+<td>
            .328
           </td>
-          <td>
+<td>
            1513
           </td>
-          <td>
+<td>
            1014
           </td>
-          <td>
+<td>
            24
           </td>
-          <td>
+<td>
            .415
           </td>
-          <td>
+<td>
            .443
           </td>
-          <td>
+<td>
            .858
           </td>
-          <td>
+<td>
            131
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999"];
             const warData = [3.9, 7.8, 6.3, 9.1, 8.1, 8.3, 8.3, 8.4, 3.2, 6.4, 2.2, 4.3, 4.5, 4.2, 3.4, 2.0, 1.4, -0.3];
             const teamsByYear = ["BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "NYY", "NYY", "NYY", "NYY", "NYY", "TBD", "TBD"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "NYY", "TBD"], "years": ["1992", "1983", "1991", "1998", "1986", "1996", "1999", "1985", "1994", "1988", "1989", "1993", "1997", "1982", "1995", "1987", "1990", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Wade Boggs", "hints": ["Recorded seven consecutive seasons with 200 or more hits.", "Hit a home run for the 3,000th career hit.", "Was the first player to have a number retired by the Tampa Bay Devil Rays."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-05.html
+++ b/2025-05-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Dave Winfield, the featured New York Yankee for the 2025-05-05 trivia puzzle." name="description"/>
+
+<title>
    Dave Winfield Answer - May 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 05, 2025: Dave Winfield. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Dave Winfield" src="images/answer-2025-05-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Dave Winfield" src="images/answer-2025-05-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Dave Winfield "Mr. May"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was drafted by professional teams in four different sports leagues: MLB, NFL, NBA, and ABA.
         </li>
-        <li>
+<li>
          Played in the major leagues without ever playing a single game in the minor leagues.
         </li>
-        <li>
+<li>
          Is the oldest player in MLB history to record 100 or more RBIs in a season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            64.2
           </td>
-          <td>
+<td>
            11003
           </td>
-          <td>
+<td>
            3110
           </td>
-          <td>
+<td>
            465
           </td>
-          <td>
+<td>
            .283
           </td>
-          <td>
+<td>
            1669
           </td>
-          <td>
+<td>
            1833
           </td>
-          <td>
+<td>
            223
           </td>
-          <td>
+<td>
            .353
           </td>
-          <td>
+<td>
            .475
           </td>
-          <td>
+<td>
            .827
           </td>
-          <td>
+<td>
            130
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1990", "1991", "1992", "1993", "1994", "1995"];
             const warData = [0.1, 2.1, 2.8, 5.1, 5.3, 4.3, 8.3, 3.9, 2.5, 3.5, 2.5, 5.3, 3.4, 3.1, 1.8, 5.4, 0.7, 0.5, 4.1, 0.2, 0.1, -1.0];
             const teamsByYear = ["SDP", "SDP", "SDP", "SDP", "SDP", "SDP", "SDP", "SDP", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "CAL", "TOR", "MIN", "MIN", "CLE"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CAL", "TOR", "SDP", "NYY", "MIN", "CLE"], "years": ["1987", "1975", "1979", "1993", "1977", "1988", "1995", "1992", "1985", "1991", "1990", "1982", "1974", "1981", "1978", "1983", "1973", "1986", "1976", "1994", "1980", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Dave Winfield", "hints": ["Was drafted by professional teams in four different sports leagues: MLB, NFL, NBA, and ABA.", "Played in the major leagues without ever playing a single game in the minor leagues.", "Is the oldest player in MLB history to record 100 or more RBIs in a season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-05.html
+++ b/2025-05-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Dave Winfield.">
   <title>
    Dave Winfield Answer - May 05, 2025 | Name That Yankee
   </title>

--- a/2025-05-06.html
+++ b/2025-05-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Kerry Wood.">
   <title>
    Kerry Wood Answer - May 06, 2025 | Name That Yankee
   </title>

--- a/2025-05-06.html
+++ b/2025-05-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Kerry Wood, the featured New York Yankee for the 2025-05-06 trivia puzzle." name="description"/>
+
+<title>
    Kerry Wood Answer - May 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 06, 2025: Kerry Wood. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Kerry Wood" src="images/answer-2025-05-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Kerry Wood" src="images/answer-2025-05-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Kerry Wood "Kid K"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Tied the major league record with 20 strikeouts in a nine-inning game.
         </li>
-        <li>
+<li>
          Was the 1998 National League Rookie of the Year.
         </li>
-        <li>
+<li>
          Struck out the only batter faced in a final career appearance.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.6
           </td>
-          <td>
+<td>
            86
           </td>
-          <td>
+<td>
            75
           </td>
-          <td>
+<td>
            3.67
           </td>
-          <td>
+<td>
            446
           </td>
-          <td>
+<td>
            178
           </td>
-          <td>
+<td>
            63
           </td>
-          <td>
+<td>
            1380.0
           </td>
-          <td>
+<td>
            1582
           </td>
-          <td>
+<td>
            1.267
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1998", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012"];
             const warData = [3.9, 1.8, 3.4, 4.4, 6.1, 2.8, 1.0, 0.0, 0.4, 1.9, 0.4, 0.9, 0.4, -0.4];
             const teamsByYear = ["CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CLE", "2TM", "CHC", "CHC"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHC", "NYY", "CLE"], "years": ["2009", "2012", "2006", "2001", "2008", "1998", "2007", "2004", "2005", "2011", "2002", "2000", "2003", "2010"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Kerry Wood", "hints": ["Tied the major league record with 20 strikeouts in a nine-inning game.", "Was the 1998 National League Rookie of the Year.", "Struck out the only batter faced in a final career appearance."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-07.html
+++ b/2025-05-07.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-07" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Andy Hawkins.">
   <title>
    Andy Hawkins Answer - May 07, 2025 | Name That Yankee
   </title>

--- a/2025-05-07.html
+++ b/2025-05-07.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-07" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-07" rel="canonical"/><meta content="Discover the career highlights and statistics for Andy Hawkins, the featured New York Yankee for the 2025-05-07 trivia puzzle." name="description"/>
+
+<title>
    Andy Hawkins Answer - May 07, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 07, 2025: Andy Hawkins. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 07, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-07.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 07, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-07.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 07, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-07.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 07, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-07.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-07"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 07, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Andy Hawkins" src="images/answer-2025-05-07.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Andy Hawkins" src="images/answer-2025-05-07.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Andy Hawkins
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched eight innings of a no-hitter in a 4-0 loss.
         </li>
-        <li>
+<li>
          Gave up two grand slams in the same inning.
         </li>
-        <li>
+<li>
          Started Game 2 of the 1984 World Series.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.3
           </td>
-          <td>
+<td>
            84
           </td>
-          <td>
+<td>
            91
           </td>
-          <td>
+<td>
            4.22
           </td>
-          <td>
+<td>
            280
           </td>
-          <td>
+<td>
            249
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            1558.1
           </td>
-          <td>
+<td>
            706
           </td>
-          <td>
+<td>
            1.403
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-07.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-07.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [-0.4, 1.2, -1.6, 3.4, 0.8, -0.4, 2.1, -0.9, -1.0, -0.4];
             const teamsByYear = ["SDP", "SDP", "SDP", "SDP", "SDP", "SDP", "SDP", "NYY", "NYY", "2TM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "SDP", "OAK"], "years": ["1983", "1989", "1986", "1987", "1990", "1988", "1991", "1985", "1984", "1982"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Andy Hawkins", "hints": ["Pitched eight innings of a no-hitter in a 4-0 loss.", "Gave up two grand slams in the same inning.", "Started Game 2 of the 1984 World Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-10.html
+++ b/2025-05-10.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-10" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Stan Javier, the featured New York Yankee for the 2025-05-10 trivia puzzle." name="description"/>
+
+<title>
    Stan Javier Answer - May 10, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 10, 2025: Stan Javier. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 10, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-10.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 10, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-10.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 10, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 10, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-10.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-10"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 10, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Stan Javier" src="images/answer-2025-05-10.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Stan Javier" src="images/answer-2025-05-10.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Stan Javier
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Father, Julián Javier, was a two-time All-Star and two-time World Series champion second baseman.
         </li>
-        <li>
+<li>
          Was the first player to play for both the San Francisco Giants and Oakland Athletics in the same season.
         </li>
-        <li>
+<li>
          Won the 1989 World Series as a member of the Oakland Athletics.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            25.5
           </td>
-          <td>
+<td>
            5047
           </td>
-          <td>
+<td>
            1358
           </td>
-          <td>
+<td>
            57
           </td>
-          <td>
+<td>
            .269
           </td>
-          <td>
+<td>
            781
           </td>
-          <td>
+<td>
            503
           </td>
-          <td>
+<td>
            246
           </td>
-          <td>
+<td>
            .345
           </td>
-          <td>
+<td>
            .363
           </td>
-          <td>
+<td>
            .708
           </td>
-          <td>
+<td>
            93
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-10.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1984", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [-0.1, 0.6, -0.5, 1.0, 1.0, 4.3, -0.4, 1.4, 1.2, 3.5, 3.5, 1.9, 3.6, 2.0, -0.5, 0.5, 2.8];
             const teamsByYear = ["NYY", "OAK", "OAK", "OAK", "OAK", "2TM", "LAD", "2TM", "CAL", "OAK", "OAK", "SFG", "SFG", "SFG", "2TM", "SEA", "SEA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "PHI", "CAL", "SFG", "HOU", "OAK", "NYY", "SEA"], "years": ["1994", "1984", "1989", "1991", "1987", "1986", "1995", "2000", "2001", "1990", "1988", "1997", "1993", "1996", "1999", "1992", "1998"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Stan Javier", "hints": ["Father, Juli\u00e1n Javier, was a two-time All-Star and two-time World Series champion second baseman.", "Was the first player to play for both the San Francisco Giants and Oakland Athletics in the same season.", "Won the 1989 World Series as a member of the Oakland Athletics."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-10.html
+++ b/2025-05-10.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-10" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Stan Javier.">
   <title>
    Stan Javier Answer - May 10, 2025 | Name That Yankee
   </title>

--- a/2025-05-11.html
+++ b/2025-05-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jim Hunter.">
   <title>
    Jim Hunter Answer - May 11, 2025 | Name That Yankee
   </title>

--- a/2025-05-11.html
+++ b/2025-05-11.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-11" rel="canonical"/><meta content="Discover the career highlights and statistics for Jim Hunter, the featured New York Yankee for the 2025-05-11 trivia puzzle." name="description"/>
+
+<title>
    Jim Hunter Answer - May 11, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 11, 2025: Jim Hunter. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 11, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 11, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-11.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 11, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 11, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-11.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-11"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 11, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jim Hunter" src="images/answer-2025-05-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jim Hunter" src="images/answer-2025-05-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jim Hunter "Catfish"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched a perfect game on May 8, 1968.
         </li>
-        <li>
+<li>
          Won 20 or more games in five consecutive seasons from 1971 to 1975.
         </li>
-        <li>
+<li>
          Was inducted into the Baseball Hall of Fame in 1987.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            40.9
           </td>
-          <td>
+<td>
            224
           </td>
-          <td>
+<td>
            166
           </td>
-          <td>
+<td>
            3.26
           </td>
-          <td>
+<td>
            500
           </td>
-          <td>
+<td>
            476
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            3449.1
           </td>
-          <td>
+<td>
            2012
           </td>
-          <td>
+<td>
            1.134
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979"];
             const warData = [0.6, 0.5, 4.6, 0.4, 2.3, 1.0, 2.7, 5.7, 1.8, 6.9, 8.1, 1.4, -0.4, 1.2, -0.4];
             const teamsByYear = ["KCA", "KCA", "KCA", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["OAK", "NYY", "KCA"], "years": ["1971", "1972", "1968", "1966", "1967", "1970", "1979", "1974", "1977", "1965", "1978", "1975", "1969", "1976", "1973"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jim Hunter", "hints": ["Pitched a perfect game on May 8, 1968.", "Won 20 or more games in five consecutive seasons from 1971 to 1975.", "Was inducted into the Baseball Hall of Fame in 1987."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-12.html
+++ b/2025-05-12.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-12" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Russ Davis.">
   <title>
    Russ Davis Answer - May 12, 2025 | Name That Yankee
   </title>

--- a/2025-05-12.html
+++ b/2025-05-12.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-12" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-12" rel="canonical"/><meta content="Discover the career highlights and statistics for Russ Davis, the featured New York Yankee for the 2025-05-12 trivia puzzle." name="description"/>
+
+<title>
    Russ Davis Answer - May 12, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 12, 2025: Russ Davis. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 12, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-12.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 12, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-12.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 12, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 12, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-12.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-12"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 12, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Russ Davis" src="images/answer-2025-05-12.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Russ Davis" src="images/answer-2025-05-12.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Russ Davis
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit 20 or more home runs in three consecutive seasons from 1996-1998.
         </li>
-        <li>
+<li>
          Set a Seattle Mariners single-season record for errors by a third baseman with 36 in 1996.
         </li>
-        <li>
+<li>
          Son, Braden, was drafted by the Baltimore Orioles in the 2022 MLB draft.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -0.3
           </td>
-          <td>
+<td>
            1980
           </td>
-          <td>
+<td>
            508
           </td>
-          <td>
+<td>
            84
           </td>
-          <td>
+<td>
            .257
           </td>
-          <td>
+<td>
            261
           </td>
-          <td>
+<td>
            276
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            .310
           </td>
-          <td>
+<td>
            .444
           </td>
-          <td>
+<td>
            .755
           </td>
-          <td>
+<td>
            94
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-12.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [-0.3, 0.5, -0.3, 1.8, -0.5, -0.9, -0.6, -0.1];
             const teamsByYear = ["NYY", "NYY", "SEA", "SEA", "SEA", "SEA", "SFG", "SFG"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SEA", "NYY", "SFG"], "years": ["2001", "1997", "1996", "1994", "1995", "2000", "1998", "1999"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Russ Davis", "hints": ["Hit 20 or more home runs in three consecutive seasons from 1996-1998.", "Set a Seattle Mariners single-season record for errors by a third baseman with 36 in 1996.", "Son, Braden, was drafted by the Baltimore Orioles in the 2022 MLB draft."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-13.html
+++ b/2025-05-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-13" rel="canonical"/><meta content="Discover the career highlights and statistics for Henry Cotto, the featured New York Yankee for the 2025-05-13 trivia puzzle." name="description"/>
+
+<title>
    Henry Cotto Answer - May 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 13, 2025: Henry Cotto. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Henry Cotto" src="images/answer-2025-05-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Henry Cotto" src="images/answer-2025-05-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Henry Cotto
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Scored the first run in Florida Marlins franchise history.
         </li>
-        <li>
+<li>
          Was the 21st player selected in the 1992 MLB expansion draft.
         </li>
-        <li>
+<li>
          Cousin of former MLB catcher Orlando Mercado.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.1
           </td>
-          <td>
+<td>
            2178
           </td>
-          <td>
+<td>
            569
           </td>
-          <td>
+<td>
            44
           </td>
-          <td>
+<td>
            .261
           </td>
-          <td>
+<td>
            296
           </td>
-          <td>
+<td>
            210
           </td>
-          <td>
+<td>
            130
           </td>
-          <td>
+<td>
            .299
           </td>
-          <td>
+<td>
            .370
           </td>
-          <td>
+<td>
            .669
           </td>
-          <td>
+<td>
            84
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993"];
             const warData = [1.2, 0.1, -0.4, 0.1, 0.8, 1.1, 0.6, 0.3, 0.7, -0.5];
             const teamsByYear = ["CHC", "NYY", "NYY", "NYY", "SEA", "SEA", "SEA", "SEA", "SEA", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "SEA", "CHC", "FLA"], "years": ["1992", "1987", "1985", "1986", "1988", "1984", "1989", "1990", "1993", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Henry Cotto", "hints": ["Scored the first run in Florida Marlins franchise history.", "Was the 21st player selected in the 1992 MLB expansion draft.", "Cousin of former MLB catcher Orlando Mercado."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-13.html
+++ b/2025-05-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Henry Cotto.">
   <title>
    Henry Cotto Answer - May 13, 2025 | Name That Yankee
   </title>

--- a/2025-05-14.html
+++ b/2025-05-14.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-14" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-14" rel="canonical"/><meta content="Discover the career highlights and statistics for Larry Milbourne, the featured New York Yankee for the 2025-05-14 trivia puzzle." name="description"/>
+
+<title>
    Larry Milbourne Answer - May 14, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 14, 2025: Larry Milbourne. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 14, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-14.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 14, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-14.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 14, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-14.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 14, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-14.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-14"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 14, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Larry Milbourne" src="images/answer-2025-05-14.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Larry Milbourne" src="images/answer-2025-05-14.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Larry Milbourne
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was traded from the New York Yankees to the Minnesota Twins for a player to be named later, who was later revealed to be himself.
         </li>
-        <li>
+<li>
          Hit a pinch-hit, go-ahead home run in Game 2 of the 1983 World Series.
         </li>
-        <li>
+<li>
          Played for eight different Major League teams in an eleven-year career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -0.5
           </td>
-          <td>
+<td>
            2448
           </td>
-          <td>
+<td>
            623
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            .254
           </td>
-          <td>
+<td>
            290
           </td>
-          <td>
+<td>
            184
           </td>
-          <td>
+<td>
            41
           </td>
-          <td>
+<td>
            .293
           </td>
-          <td>
+<td>
            .317
           </td>
-          <td>
+<td>
            .609
           </td>
-          <td>
+<td>
            70
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-14.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-14.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984"];
             const warData = [1.1, -0.5, 0.1, -0.6, -0.8, 1.0, 0.4, 1.2, -1.1, -0.7, -0.7];
             const teamsByYear = ["HOU", "HOU", "HOU", "SEA", "SEA", "SEA", "SEA", "NYY", "3TM", "2TM", "SEA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYY", "MIN", "HOU", "SEA", "PHI"], "years": ["1979", "1976", "1984", "1978", "1974", "1983", "1977", "1981", "1980", "1975", "1982"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Larry Milbourne", "hints": ["Was traded from the New York Yankees to the Minnesota Twins for a player to be named later, who was later revealed to be himself.", "Hit a pinch-hit, go-ahead home run in Game 2 of the 1983 World Series.", "Played for eight different Major League teams in an eleven-year career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-14.html
+++ b/2025-05-14.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-14" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Larry Milbourne.">
   <title>
    Larry Milbourne Answer - May 14, 2025 | Name That Yankee
   </title>

--- a/2025-05-16.html
+++ b/2025-05-16.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-16" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Kevin Elster.">
   <title>
    Kevin Elster Answer - May 16, 2025 | Name That Yankee
   </title>

--- a/2025-05-16.html
+++ b/2025-05-16.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-16" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-16" rel="canonical"/><meta content="Discover the career highlights and statistics for Kevin Elster, the featured New York Yankee for the 2025-05-16 trivia puzzle." name="description"/>
+
+<title>
    Kevin Elster Answer - May 16, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 16, 2025: Kevin Elster. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 16, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-16.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 16, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-16.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 16, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-16.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 16, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-16.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-16"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 16, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Kevin Elster" src="images/answer-2025-05-16.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Kevin Elster" src="images/answer-2025-05-16.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Kevin Elster
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Set a major league record for shortstops with an 88-game errorless streak spanning the 1988-1989 seasons.
         </li>
-        <li>
+<li>
          Established career highs with 24 home runs and 99 RBI in 1996 after a two-year absence from MLB.
         </li>
-        <li>
+<li>
          Hit three home runs on Opening Day for the Los Angeles Dodgers in 2000.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.2
           </td>
-          <td>
+<td>
            2844
           </td>
-          <td>
+<td>
            648
           </td>
-          <td>
+<td>
            88
           </td>
-          <td>
+<td>
            .228
           </td>
-          <td>
+<td>
            332
           </td>
-          <td>
+<td>
            376
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            .300
           </td>
-          <td>
+<td>
            .377
           </td>
-          <td>
+<td>
            .677
           </td>
-          <td>
+<td>
            83
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-16.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-16.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1986", "1987", "1988", "1989", "1990", "1991", "1992", "1994", "1995", "1996", "1997", "1998", "2000"];
             const warData = [0.1, 0.1, 1.3, 2.3, -0.2, 1.2, -0.1, -0.5, -0.1, 1.4, 0.0, 0.3, 0.5];
             const teamsByYear = ["NYM", "NYM", "NYM", "NYM", "NYM", "NYM", "NYM", "NYY", "2TM", "TEX", "PIT", "TEX", "LAD"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "PIT", "PHI", "LAD", "NYM", "TEX"], "years": ["1997", "2000", "1995", "1991", "1986", "1994", "1988", "1998", "1989", "1996", "1990", "1992", "1987"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Kevin Elster", "hints": ["Set a major league record for shortstops with an 88-game errorless streak spanning the 1988-1989 seasons.", "Established career highs with 24 home runs and 99 RBI in 1996 after a two-year absence from MLB.", "Hit three home runs on Opening Day for the Los Angeles Dodgers in 2000."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-20.html
+++ b/2025-05-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Willie Calhoun.">
   <title>
    Willie Calhoun Answer - May 20, 2025 | Name That Yankee
   </title>

--- a/2025-05-20.html
+++ b/2025-05-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-20" rel="canonical"/><meta content="Discover the career highlights and statistics for Willie Calhoun, the featured New York Yankee for the 2025-05-20 trivia puzzle." name="description"/>
+
+<title>
    Willie Calhoun Answer - May 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 20, 2025: Willie Calhoun. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Willie Calhoun" src="images/answer-2025-05-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Willie Calhoun" src="images/answer-2025-05-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Willie Calhoun
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the key prospect acquired by the Texas Rangers in the 2017 trade for Yu Darvish.
         </li>
-        <li>
+<li>
          Hit 31 home runs across two minor league levels in 2017.
         </li>
-        <li>
+<li>
          Hit 21 home runs in 83 games for the Texas Rangers in 2019.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -2.1
           </td>
-          <td>
+<td>
            1217
           </td>
-          <td>
+<td>
            293
           </td>
-          <td>
+<td>
            42
           </td>
-          <td>
+<td>
            .241
           </td>
-          <td>
+<td>
            140
           </td>
-          <td>
+<td>
            140
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            .303
           </td>
-          <td>
+<td>
            .399
           </td>
-          <td>
+<td>
            .703
           </td>
-          <td>
+<td>
            88
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"];
             const warData = [-0.1, -0.7, 0.8, -1.0, -0.4, -0.4, -0.2, -0.2];
             const teamsByYear = ["TEX", "TEX", "TEX", "TEX", "TEX", "2TM", "NYY", "LAA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAA", "NYY", "TEX", "SFG"], "years": ["2017", "2019", "2024", "2022", "2020", "2021", "2018", "2023"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Willie Calhoun", "hints": ["Was the key prospect acquired by the Texas Rangers in the 2017 trade for Yu Darvish.", "Hit 31 home runs across two minor league levels in 2017.", "Hit 21 home runs in 83 games for the Texas Rangers in 2019."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-21.html
+++ b/2025-05-21.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-21" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mike Stanley.">
   <title>
    Mike Stanley Answer - May 21, 2025 | Name That Yankee
   </title>

--- a/2025-05-21.html
+++ b/2025-05-21.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-21" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-21" rel="canonical"/><meta content="Discover the career highlights and statistics for Mike Stanley, the featured New York Yankee for the 2025-05-21 trivia puzzle." name="description"/>
+
+<title>
    Mike Stanley Answer - May 21, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 21, 2025: Mike Stanley. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 21, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-21.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 21, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-21.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 21, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-21.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 21, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-21.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-21"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 21, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mike Stanley" src="images/answer-2025-05-21.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mike Stanley" src="images/answer-2025-05-21.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mike Stanley
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won an American League Silver Slugger Award as a catcher in 1993.
         </li>
-        <li>
+<li>
          Was selected as a 1995 American League All-Star.
         </li>
-        <li>
+<li>
          Was drafted four separate times before signing a professional contract.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            20.9
           </td>
-          <td>
+<td>
            4222
           </td>
-          <td>
+<td>
            1138
           </td>
-          <td>
+<td>
            187
           </td>
-          <td>
+<td>
            .270
           </td>
-          <td>
+<td>
            625
           </td>
-          <td>
+<td>
            702
           </td>
-          <td>
+<td>
            13
           </td>
-          <td>
+<td>
            .370
           </td>
-          <td>
+<td>
            .458
           </td>
-          <td>
+<td>
            .827
           </td>
-          <td>
+<td>
            117
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-21.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-21.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000"];
             const warData = [0.1, -0.3, -0.8, -0.5, 0.4, 0.8, 1.3, 4.8, 3.6, 3.0, 2.5, 1.6, 2.2, 1.9, 0.4];
             const teamsByYear = ["TEX", "TEX", "TEX", "TEX", "TEX", "TEX", "NYY", "NYY", "NYY", "NYY", "BOS", "2TM", "2TM", "BOS", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TOR", "BOS", "NYY", "TEX", "OAK"], "years": ["1987", "1988", "1993", "1996", "1998", "1989", "1986", "1994", "1999", "1991", "1997", "1995", "1990", "2000", "1992"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mike Stanley", "hints": ["Won an American League Silver Slugger Award as a catcher in 1993.", "Was selected as a 1995 American League All-Star.", "Was drafted four separate times before signing a professional contract."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-22.html
+++ b/2025-05-22.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-22" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-22" rel="canonical"/><meta content="Discover the career highlights and statistics for George Medich, the featured New York Yankee for the 2025-05-22 trivia puzzle." name="description"/>
+
+<title>
    George Medich Answer - May 22, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 22, 2025: George Medich. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 22, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-22.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 22, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-22.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 22, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-22.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 22, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-22.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-22"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 22, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of George Medich" src="images/answer-2025-05-22.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of George Medich" src="images/answer-2025-05-22.webp"/>
+</div>
+<div class="player-info">
+<h2>
         George Medich "Doc"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Attended medical school during the off-seasons of an 11-year major league career.
         </li>
-        <li>
+<li>
          Saved a fan's life by performing CPR in the stands during a 1976 game.
         </li>
-        <li>
+<li>
          Led the American League in shutouts with seven in 1975.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            19.6
           </td>
-          <td>
+<td>
            124
           </td>
-          <td>
+<td>
            105
           </td>
-          <td>
+<td>
            3.78
           </td>
-          <td>
+<td>
            312
           </td>
-          <td>
+<td>
            287
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            1996.2
           </td>
-          <td>
+<td>
            955
           </td>
-          <td>
+<td>
            1.332
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-22.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-22.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982"];
             const warData = [0.0, 4.8, 2.9, 3.5, 1.3, 0.9, 1.8, 0.7, 2.5, 1.7, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "PIT", "3TM", "TEX", "TEX", "TEX", "TEX", "2TM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SEA", "NYY", "NYM", "MIL", "OAK", "PIT", "TEX", "2TM"], "years": ["1976", "1980", "1975", "1981", "1982", "1972", "1979", "1973", "1977", "1978", "1974"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "George Medich", "hints": ["Attended medical school during the off-seasons of an 11-year major league career.", "Saved a fan's life by performing CPR in the stands during a 1976 game.", "Led the American League in shutouts with seven in 1975."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-22.html
+++ b/2025-05-22.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-22" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is George Medich.">
   <title>
    George Medich Answer - May 22, 2025 | Name That Yankee
   </title>

--- a/2025-05-23.html
+++ b/2025-05-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jerry Coleman.">
   <title>
    Jerry Coleman Answer - May 23, 2025 | Name That Yankee
   </title>

--- a/2025-05-23.html
+++ b/2025-05-23.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Jerry Coleman, the featured New York Yankee for the 2025-05-23 trivia puzzle." name="description"/>
+
+<title>
    Jerry Coleman Answer - May 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 23, 2025: Jerry Coleman. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jerry Coleman" src="images/answer-2025-05-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jerry Coleman" src="images/answer-2025-05-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jerry Coleman "The Colonel"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was named the 1949 World Series MVP.
         </li>
-        <li>
+<li>
          Is the only major league baseball player to see combat in two wars.
         </li>
-        <li>
+<li>
          Received the Ford C. Frick Award from the Baseball Hall of Fame in 2005.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.5
           </td>
-          <td>
+<td>
            2119
           </td>
-          <td>
+<td>
            558
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            .263
           </td>
-          <td>
+<td>
            267
           </td>
-          <td>
+<td>
            217
           </td>
-          <td>
+<td>
            22
           </td>
-          <td>
+<td>
            .340
           </td>
-          <td>
+<td>
            .339
           </td>
-          <td>
+<td>
            .680
           </td>
-          <td>
+<td>
            83
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1949", "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957"];
             const warData = [2.5, 2.8, 1.0, 0.8, 0.0, -0.3, -0.2, -0.5, 0.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1950", "1957", "1952", "1951", "1954", "1953", "1956", "1955", "1949"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jerry Coleman", "hints": ["Was named the 1949 World Series MVP.", "Is the only major league baseball player to see combat in two wars.", "Received the Ford C. Frick Award from the Baseball Hall of Fame in 2005."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-24.html
+++ b/2025-05-24.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-24" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ralph Houk.">
   <title>
    Ralph Houk Answer - May 24, 2025 | Name That Yankee
   </title>

--- a/2025-05-24.html
+++ b/2025-05-24.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-24" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-24" rel="canonical"/><meta content="Discover the career highlights and statistics for Ralph Houk, the featured New York Yankee for the 2025-05-24 trivia puzzle." name="description"/>
+
+<title>
    Ralph Houk Answer - May 24, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 24, 2025: Ralph Houk. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 24, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-24.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 24, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-24.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 24, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-24.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 24, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-24.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-24"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 24, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ralph Houk" src="images/answer-2025-05-24.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ralph Houk" src="images/answer-2025-05-24.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ralph Houk "The Major"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the World Series in each of the first two seasons as a manager.
         </li>
-        <li>
+<li>
          Won the American League pennant in each of the first three seasons as a manager.
         </li>
-        <li>
+<li>
          Hit zero home runs in an eight-season MLB playing career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            0.1
           </td>
-          <td>
+<td>
            158
           </td>
-          <td>
+<td>
            43
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            .272
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            20
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            .327
           </td>
-          <td>
+<td>
            .323
           </td>
-          <td>
+<td>
            .650
           </td>
-          <td>
+<td>
            79
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-24.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-24.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1947", "1948", "1949", "1950", "1951", "1952", "1953"];
             const warData = [0.1, 0.1, 0.1, -0.1, 0.0, 0.0, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1947", "1950", "1949", "1948", "1952", "1953", "1951"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ralph Houk", "hints": ["Won the World Series in each of the first two seasons as a manager.", "Won the American League pennant in each of the first three seasons as a manager.", "Hit zero home runs in an eight-season MLB playing career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-25.html
+++ b/2025-05-25.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-25" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Phil Rizzuto.">
   <title>
    Phil Rizzuto Answer - May 25, 2025 | Name That Yankee
   </title>

--- a/2025-05-25.html
+++ b/2025-05-25.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-25" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-25" rel="canonical"/><meta content="Discover the career highlights and statistics for Phil Rizzuto, the featured New York Yankee for the 2025-05-25 trivia puzzle." name="description"/>
+
+<title>
    Phil Rizzuto Answer - May 25, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 25, 2025: Phil Rizzuto. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 25, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-25.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 25, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-25.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 25, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-25.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 25, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-25.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-25"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 25, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Phil Rizzuto" src="images/answer-2025-05-25.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Phil Rizzuto" src="images/answer-2025-05-25.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Phil Rizzuto "The Scooter"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the 1950 American League Most Valuable Player.
         </li>
-        <li>
+<li>
          Missed three seasons from 1943 to 1945 while serving in the U.S. Navy during World War II.
         </li>
-        <li>
+<li>
          Led the American League in sacrifice hits for four consecutive seasons from 1949-1952.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            42.1
           </td>
-          <td>
+<td>
            5816
           </td>
-          <td>
+<td>
            1588
           </td>
-          <td>
+<td>
            38
           </td>
-          <td>
+<td>
            .273
           </td>
-          <td>
+<td>
            877
           </td>
-          <td>
+<td>
            563
           </td>
-          <td>
+<td>
            149
           </td>
-          <td>
+<td>
            .351
           </td>
-          <td>
+<td>
            .355
           </td>
-          <td>
+<td>
            .706
           </td>
-          <td>
+<td>
            93
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-25.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-25.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1941", "1942", "1946", "1947", "1948", "1949", "1950", "1951", "1952", "1953", "1954", "1955", "1956"];
             const warData = [4.6, 5.8, 2.2, 4.6, 1.6, 3.0, 6.8, 3.6, 5.3, 3.9, 0.1, 0.7, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1947", "1941", "1950", "1955", "1949", "1956", "1948", "1946", "1952", "1942", "1954", "1953", "1951"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Phil Rizzuto", "hints": ["Was the 1950 American League Most Valuable Player.", "Missed three seasons from 1943 to 1945 while serving in the U.S. Navy during World War II.", "Led the American League in sacrifice hits for four consecutive seasons from 1949-1952."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-26.html
+++ b/2025-05-26.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-26" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Whitey Ford.">
   <title>
    Whitey Ford Answer - May 26, 2025 | Name That Yankee
   </title>

--- a/2025-05-26.html
+++ b/2025-05-26.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-26" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-26" rel="canonical"/><meta content="Discover the career highlights and statistics for Whitey Ford, the featured New York Yankee for the 2025-05-26 trivia puzzle." name="description"/>
+
+<title>
    Whitey Ford Answer - May 26, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 26, 2025: Whitey Ford. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 26, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-26.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 26, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-26.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 26, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-26.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 26, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-26.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-26"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 26, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Whitey Ford" src="images/answer-2025-05-26.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Whitey Ford" src="images/answer-2025-05-26.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Whitey Ford "The Chairman of the Board"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Holds the highest winning percentage (.690) among modern-era pitchers with 300 or more decisions.
         </li>
-        <li>
+<li>
          Set a World Series record with 33 2/3 consecutive scoreless innings pitched.
         </li>
-        <li>
+<li>
          Is the all-time leader in World Series victories with 10.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            57.0
           </td>
-          <td>
+<td>
            236
           </td>
-          <td>
+<td>
            106
           </td>
-          <td>
+<td>
            2.75
           </td>
-          <td>
+<td>
            498
           </td>
-          <td>
+<td>
            438
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            3170.1
           </td>
-          <td>
+<td>
            1956
           </td>
-          <td>
+<td>
            1.215
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-26.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-26.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1950", "1953", "1954", "1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967"];
             const warData = [2.5, 2.5, 3.6, 3.8, 5.2, 1.9, 4.3, 2.5, 2.0, 3.7, 5.1, 4.3, 6.7, 3.8, 0.3, 1.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1959", "1958", "1964", "1955", "1953", "1966", "1961", "1962", "1965", "1950", "1967", "1954", "1960", "1956", "1963", "1957"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Whitey Ford", "hints": ["Holds the highest winning percentage (.690) among modern-era pitchers with 300 or more decisions.", "Set a World Series record with 33 2/3 consecutive scoreless innings pitched.", "Is the all-time leader in World Series victories with 10."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-27.html
+++ b/2025-05-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Mike Heath, the featured New York Yankee for the 2025-05-27 trivia puzzle." name="description"/>
+
+<title>
    Mike Heath Answer - May 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 27, 2025: Mike Heath. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-05-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mike Heath" src="images/answer-2025-05-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mike Heath" src="images/answer-2025-05-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mike Heath "Heater"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Played every position on the field except for pitcher.
         </li>
-        <li>
+<li>
          Was traded twice on the same day, November 10, 1978.
         </li>
-        <li>
+<li>
          Caught Mike Warren's no-hitter on September 29, 1983.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            13.4
           </td>
-          <td>
+<td>
            4212
           </td>
-          <td>
+<td>
            1061
           </td>
-          <td>
+<td>
            86
           </td>
-          <td>
+<td>
            .252
           </td>
-          <td>
+<td>
            462
           </td>
-          <td>
+<td>
            469
           </td>
-          <td>
+<td>
            54
           </td>
-          <td>
+<td>
            .300
           </td>
-          <td>
+<td>
            .367
           </td>
-          <td>
+<td>
            .667
           </td>
-          <td>
+<td>
            88
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [-0.2, -0.5, 0.3, 1.4, 0.9, 0.9, 2.0, 2.9, 0.3, 1.7, 0.7, 2.7, 0.9, -0.7];
             const teamsByYear = ["NYY", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "2TM", "DET", "DET", "DET", "DET", "ATL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["OAK", "STL", "DET", "ATL", "NYY"], "years": ["1991", "1983", "1989", "1979", "1987", "1988", "1990", "1985", "1981", "1980", "1984", "1986", "1982", "1978"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mike Heath", "hints": ["Played every position on the field except for pitcher.", "Was traded twice on the same day, November 10, 1978.", "Caught Mike Warren's no-hitter on September 29, 1983."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-27.html
+++ b/2025-05-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mike Heath.">
   <title>
    Mike Heath Answer - May 27, 2025 | Name That Yankee
   </title>

--- a/2025-05-28.html
+++ b/2025-05-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-05-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-05-28" rel="canonical"/><meta content="Discover the career highlights and statistics for John Candelaria, the featured New York Yankee for the 2025-05-28 trivia puzzle." name="description"/>
+
+<title>
    John Candelaria Answer - May 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on May 28, 2025: John Candelaria. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - May 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-05-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - May 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-05-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - May 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-05-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - May 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-05-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-05-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for May 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of John Candelaria" src="images/answer-2025-05-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of John Candelaria" src="images/answer-2025-05-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         John Candelaria "The Candy Man"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Threw the only no-hitter by a Pirates pitcher at Three Rivers Stadium.
         </li>
-        <li>
+<li>
          Led the National League with a 2.34 ERA in 1977.
         </li>
-        <li>
+<li>
          Named the American League Comeback Player of the Year in 1986.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            41.9
           </td>
-          <td>
+<td>
            177
           </td>
-          <td>
+<td>
            122
           </td>
-          <td>
+<td>
            3.33
           </td>
-          <td>
+<td>
            600
           </td>
-          <td>
+<td>
            356
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            2525.2
           </td>
-          <td>
+<td>
            1673
           </td>
-          <td>
+<td>
            1.184
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-05-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-05-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993"];
             const warData = [1.5, 2.5, 7.4, 4.0, 3.5, 1.0, 0.7, 4.0, 4.5, 3.3, 1.4, 2.3, 0.1, 2.6, -0.1, 1.1, 0.1, 0.9, -1.0];
             const teamsByYear = ["PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "2TM", "CAL", "2TM", "NYY", "2TM", "2TM", "LAD", "LAD", "PIT"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "MIN", "CAL", "MON", "NYM", "NYY", "PIT", "TOR"], "years": ["1990", "1977", "1979", "1992", "1982", "1987", "1980", "1981", "1975", "1988", "1993", "1983", "1976", "1986", "1985", "1978", "1991", "1989", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "John Candelaria", "hints": ["Threw the only no-hitter by a Pirates pitcher at Three Rivers Stadium.", "Led the National League with a 2.34 ERA in 1977.", "Named the American League Comeback Player of the Year in 1986."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-05-28.html
+++ b/2025-05-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-05-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is John Candelaria.">
   <title>
    John Candelaria Answer - May 28, 2025 | Name That Yankee
   </title>

--- a/2025-06-03.html
+++ b/2025-06-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is CC Sabathia.">
   <title>
    CC Sabathia Answer - June 03, 2025 | Name That Yankee
   </title>

--- a/2025-06-03.html
+++ b/2025-06-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-03" rel="canonical"/><meta content="Discover the career highlights and statistics for CC Sabathia, the featured New York Yankee for the 2025-06-03 trivia puzzle." name="description"/>
+
+<title>
    CC Sabathia Answer - June 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 03, 2025: CC Sabathia. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of CC Sabathia" src="images/answer-2025-06-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of CC Sabathia" src="images/answer-2025-06-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         CC Sabathia "CC"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 2007 American League Cy Young Award.
         </li>
-        <li>
+<li>
          Is one of three left-handed pitchers to record 3,000 career strikeouts.
         </li>
-        <li>
+<li>
          Was the 2009 American League Championship Series MVP.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            62.3
           </td>
-          <td>
+<td>
            251
           </td>
-          <td>
+<td>
            161
           </td>
-          <td>
+<td>
            3.74
           </td>
-          <td>
+<td>
            561
           </td>
-          <td>
+<td>
            560
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            3577.1
           </td>
-          <td>
+<td>
            3093
           </td>
-          <td>
+<td>
            1.259
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019"];
             const warData = [2.9, 3.3, 3.7, 3.1, 1.8, 4.6, 6.3, 6.7, 6.2, 4.8, 6.4, 3.4, 0.0, -0.6, 1.1, 3.1, 2.8, 1.8, 0.4];
             const teamsByYear = ["CLE", "CLE", "CLE", "CLE", "CLE", "CLE", "CLE", "2TM", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MIL", "NYY", "CLE"], "years": ["2015", "2003", "2017", "2016", "2005", "2007", "2014", "2018", "2011", "2004", "2002", "2006", "2013", "2012", "2008", "2019", "2010", "2009", "2001"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "CC Sabathia", "hints": ["Won the 2007 American League Cy Young Award.", "Is one of three left-handed pitchers to record 3,000 career strikeouts.", "Was the 2009 American League Championship Series MVP."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-04.html
+++ b/2025-06-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ron Hassey.">
   <title>
    Ron Hassey Answer - June 04, 2025 | Name That Yankee
   </title>

--- a/2025-06-04.html
+++ b/2025-06-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Ron Hassey, the featured New York Yankee for the 2025-06-04 trivia puzzle." name="description"/>
+
+<title>
    Ron Hassey Answer - June 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 04, 2025: Ron Hassey. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ron Hassey" src="images/answer-2025-06-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ron Hassey" src="images/answer-2025-06-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ron Hassey
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Is the only catcher in MLB history to catch two perfect games.
         </li>
-        <li>
+<li>
          Caught perfect games in both the American and National Leagues.
         </li>
-        <li>
+<li>
          Was traded for Rick Sutcliffe during Sutcliffe's 1984 Cy Young Award-winning season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.7
           </td>
-          <td>
+<td>
            3440
           </td>
-          <td>
+<td>
            914
           </td>
-          <td>
+<td>
            71
           </td>
-          <td>
+<td>
            .266
           </td>
-          <td>
+<td>
            348
           </td>
-          <td>
+<td>
            438
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            .340
           </td>
-          <td>
+<td>
            .382
           </td>
-          <td>
+<td>
            .722
           </td>
-          <td>
+<td>
            100
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [-0.3, 0.7, 3.8, 1.0, 1.0, 1.8, 0.4, 1.6, 2.9, -0.6, 1.7, 0.2, 0.6, 0.1];
             const teamsByYear = ["CLE", "CLE", "CLE", "CLE", "CLE", "CLE", "2TM", "NYY", "2TM", "CHW", "OAK", "OAK", "OAK", "MON"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYY", "CHW", "OAK", "MON", "CHC"], "years": ["1991", "1990", "1980", "1984", "1982", "1981", "1985", "1978", "1983", "1986", "1987", "1988", "1979", "1989"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ron Hassey", "hints": ["Is the only catcher in MLB history to catch two perfect games.", "Caught perfect games in both the American and National Leagues.", "Was traded for Rick Sutcliffe during Sutcliffe's 1984 Cy Young Award-winning season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-05.html
+++ b/2025-06-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Walt Williams.">
   <title>
    Walt Williams Answer - June 05, 2025 | Name That Yankee
   </title>

--- a/2025-06-05.html
+++ b/2025-06-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Walt Williams, the featured New York Yankee for the 2025-06-05 trivia puzzle." name="description"/>
+
+<title>
    Walt Williams Answer - June 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 05, 2025: Walt Williams. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Walt Williams" src="images/answer-2025-06-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Walt Williams" src="images/answer-2025-06-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Walt Williams "No-Neck"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit for the cycle on July 22, 1967.
         </li>
-        <li>
+<li>
          Finished 20th in the 1969 American League MVP voting.
         </li>
-        <li>
+<li>
          Played two seasons in Japan for the Nippon-Ham Fighters after a 10-year MLB career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.4
           </td>
-          <td>
+<td>
            2373
           </td>
-          <td>
+<td>
            640
           </td>
-          <td>
+<td>
            33
           </td>
-          <td>
+<td>
            .270
           </td>
-          <td>
+<td>
            284
           </td>
-          <td>
+<td>
            173
           </td>
-          <td>
+<td>
            34
           </td>
-          <td>
+<td>
            .310
           </td>
-          <td>
+<td>
            .365
           </td>
-          <td>
+<td>
            .675
           </td>
-          <td>
+<td>
            91
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1964", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975"];
             const warData = [-0.2, 0.2, -0.4, 1.6, -0.6, 1.6, 0.0, 1.1, -1.1, 0.2];
             const teamsByYear = ["HOU", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "CLE", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "CHW", "NYY", "HOU"], "years": ["1969", "1970", "1964", "1975", "1973", "1974", "1968", "1971", "1967", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Walt Williams", "hints": ["Hit for the cycle on July 22, 1967.", "Finished 20th in the 1969 American League MVP voting.", "Played two seasons in Japan for the Nippon-Ham Fighters after a 10-year MLB career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-06.html
+++ b/2025-06-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Charles Herbert Ruffing.">
   <title>
    Charles Herbert Ruffing Answer - June 06, 2025 | Name That Yankee
   </title>

--- a/2025-06-06.html
+++ b/2025-06-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Charles Herbert Ruffing, the featured New York Yankee for the 2025-06-06 trivia puzzle." name="description"/>
+
+<title>
    Charles Herbert Ruffing Answer - June 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 06, 2025: Charles Herbert Ruffing. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Charles Herbert Ruffing" src="images/answer-2025-06-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Charles Herbert Ruffing" src="images/answer-2025-06-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Charles Herbert Ruffing "Red"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Lost four toes on the left foot in a mining accident as a teenager.
         </li>
-        <li>
+<li>
          Ranks fourth all-time among pitchers with 36 career home runs.
         </li>
-        <li>
+<li>
          Won six World Series championships in seven appearances with the New York Yankees.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            68.6
           </td>
-          <td>
+<td>
            273
           </td>
-          <td>
+<td>
            225
           </td>
-          <td>
+<td>
            3.80
           </td>
-          <td>
+<td>
            624
           </td>
-          <td>
+<td>
            538
           </td>
-          <td>
+<td>
            18
           </td>
-          <td>
+<td>
            4344.0
           </td>
-          <td>
+<td>
            1987
           </td>
-          <td>
+<td>
            1.341
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1924", "1925", "1926", "1927", "1928", "1929", "1930", "1931", "1932", "1933", "1934", "1935", "1936", "1937", "1938", "1939", "1940", "1941", "1942", "1945", "1946", "1947"];
             const warData = [0.0, 0.0, 0.0, 0.2, 1.5, 1.1, 1.7, 1.2, 1.3, 0.6, 0.5, 1.4, 1.1, -0.2, 0.8, 0.6, -0.5, 1.0, 0.7, 0.2, -0.2, 0.1];
             const teamsByYear = ["BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "2TM", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CHW"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHW", "BOS", "NYY"], "years": ["1945", "1941", "1935", "1929", "1936", "1925", "1946", "1938", "1940", "1924", "1931", "1928", "1942", "1926", "1937", "1939", "1947", "1932", "1927", "1930", "1934", "1933"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Charles Herbert Ruffing", "hints": ["Lost four toes on the left foot in a mining accident as a teenager.", "Ranks fourth all-time among pitchers with 36 career home runs.", "Won six World Series championships in seven appearances with the New York Yankees."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-10.html
+++ b/2025-06-10.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-10" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Johnny Damon, the featured New York Yankee for the 2025-06-10 trivia puzzle." name="description"/>
+
+<title>
    Johnny Damon Answer - June 10, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 10, 2025: Johnny Damon. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 10, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-10.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 10, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-10.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 10, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 10, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-10.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-10"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 10, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Johnny Damon" src="images/answer-2025-06-10.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Johnny Damon" src="images/answer-2025-06-10.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Johnny Damon "Caveman"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a World Series with both the Boston Red Sox and the New York Yankees.
         </li>
-        <li>
+<li>
          Is one of only ten players in MLB history with at least 2,700 career hits and 400 stolen bases.
         </li>
-        <li>
+<li>
          Hit a grand slam in Game 7 of the 2004 American League Championship Series.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            56.3
           </td>
-          <td>
+<td>
            9736
           </td>
-          <td>
+<td>
            2769
           </td>
-          <td>
+<td>
            235
           </td>
-          <td>
+<td>
            .284
           </td>
-          <td>
+<td>
            1668
           </td>
-          <td>
+<td>
            1139
           </td>
-          <td>
+<td>
            408
           </td>
-          <td>
+<td>
            .352
           </td>
-          <td>
+<td>
            .433
           </td>
-          <td>
+<td>
            .785
           </td>
-          <td>
+<td>
            104
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-10.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012"];
             const warData = [1.4, 0.5, 2.2, 1.7, 5.4, 6.2, 2.4, 4.8, 3.4, 4.3, 4.0, 3.4, 2.7, 4.2, 4.2, 3.0, 2.5, 0.3];
             const teamsByYear = ["KCR", "KCR", "KCR", "KCR", "KCR", "KCR", "OAK", "BOS", "BOS", "BOS", "BOS", "NYY", "NYY", "NYY", "NYY", "DET", "TBR", "CLE"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "KCR", "DET", "NYY", "CLE", "OAK", "TBR"], "years": ["2005", "2000", "2012", "2009", "1997", "2004", "2010", "2008", "2001", "2007", "2002", "1999", "1995", "1998", "2011", "2003", "1996", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Johnny Damon", "hints": ["Won a World Series with both the Boston Red Sox and the New York Yankees.", "Is one of only ten players in MLB history with at least 2,700 career hits and 400 stolen bases.", "Hit a grand slam in Game 7 of the 2004 American League Championship Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-10.html
+++ b/2025-06-10.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-10" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Johnny Damon.">
   <title>
    Johnny Damon Answer - June 10, 2025 | Name That Yankee
   </title>

--- a/2025-06-11.html
+++ b/2025-06-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Dick Howser.">
   <title>
    Dick Howser Answer - June 11, 2025 | Name That Yankee
   </title>

--- a/2025-06-11.html
+++ b/2025-06-11.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-11" rel="canonical"/><meta content="Discover the career highlights and statistics for Dick Howser, the featured New York Yankee for the 2025-06-11 trivia puzzle." name="description"/>
+
+<title>
    Dick Howser Answer - June 11, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 11, 2025: Dick Howser. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 11, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 11, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-11.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 11, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 11, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-11.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-11"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 11, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Dick Howser" src="images/answer-2025-06-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Dick Howser" src="images/answer-2025-06-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Dick Howser
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was named the 1961 American League Rookie of the Year by The Sporting News.
         </li>
-        <li>
+<li>
          Managed the New York Yankees to a 103-win season in 1980.
         </li>
-        <li>
+<li>
          Managed the Kansas City Royals to the 1985 World Series championship.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            9.3
           </td>
-          <td>
+<td>
            2483
           </td>
-          <td>
+<td>
            617
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            .248
           </td>
-          <td>
+<td>
            398
           </td>
-          <td>
+<td>
            165
           </td>
-          <td>
+<td>
            105
           </td>
-          <td>
+<td>
            .346
           </td>
-          <td>
+<td>
            .318
           </td>
-          <td>
+<td>
            .664
           </td>
-          <td>
+<td>
            87
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968"];
             const warData = [2.8, 1.4, -0.4, 2.7, 1.8, 0.1, 0.4, 0.4];
             const teamsByYear = ["KCA", "KCA", "2TM", "CLE", "CLE", "CLE", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CLE", "KCA"], "years": ["1965", "1968", "1964", "1961", "1963", "1967", "1962", "1966"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Dick Howser", "hints": ["Was named the 1961 American League Rookie of the Year by The Sporting News.", "Managed the New York Yankees to a 103-win season in 1980.", "Managed the Kansas City Royals to the 1985 World Series championship."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-12.html
+++ b/2025-06-12.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-12" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Don Slaught.">
   <title>
    Don Slaught Answer - June 12, 2025 | Name That Yankee
   </title>

--- a/2025-06-12.html
+++ b/2025-06-12.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-12" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-12" rel="canonical"/><meta content="Discover the career highlights and statistics for Don Slaught, the featured New York Yankee for the 2025-06-12 trivia puzzle." name="description"/>
+
+<title>
    Don Slaught Answer - June 12, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 12, 2025: Don Slaught. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 12, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-12.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 12, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-12.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 12, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 12, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-12.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-12"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 12, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Don Slaught" src="images/answer-2025-06-12.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Don Slaught" src="images/answer-2025-06-12.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Don Slaught
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit a go-ahead, ninth-inning home run in Game 1 of the 1992 NLCS.
         </li>
-        <li>
+<li>
          Posted a batting average over .300 in five separate seasons.
         </li>
-        <li>
+<li>
          Hit .373 as a pinch-hitter during the 1996 season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            19.3
           </td>
-          <td>
+<td>
            4063
           </td>
-          <td>
+<td>
            1151
           </td>
-          <td>
+<td>
            77
           </td>
-          <td>
+<td>
            .283
           </td>
-          <td>
+<td>
            415
           </td>
-          <td>
+<td>
            476
           </td>
-          <td>
+<td>
            18
           </td>
-          <td>
+<td>
            .338
           </td>
-          <td>
+<td>
            .412
           </td>
-          <td>
+<td>
            .749
           </td>
-          <td>
+<td>
            104
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-12.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997"];
             const warData = [0.6, 1.2, 1.3, 2.0, 0.2, -0.1, 1.8, 1.8, 2.3, 2.3, 2.6, 1.9, 0.9, 0.2, 0.7, -0.4];
             const teamsByYear = ["KCR", "KCR", "KCR", "TEX", "TEX", "TEX", "NYY", "NYY", "PIT", "PIT", "PIT", "PIT", "PIT", "PIT", "2TM", "SDP"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CAL", "CHW", "PIT", "NYY", "SDP", "KCR", "TEX"], "years": ["1992", "1986", "1993", "1990", "1982", "1985", "1994", "1987", "1983", "1991", "1989", "1997", "1995", "1984", "1996", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Don Slaught", "hints": ["Hit a go-ahead, ninth-inning home run in Game 1 of the 1992 NLCS.", "Posted a batting average over .300 in five separate seasons.", "Hit .373 as a pinch-hitter during the 1996 season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-13.html
+++ b/2025-06-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-13" rel="canonical"/><meta content="Discover the career highlights and statistics for George Scott, the featured New York Yankee for the 2025-06-13 trivia puzzle." name="description"/>
+
+<title>
    George Scott Answer - June 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 13, 2025: George Scott. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of George Scott" src="images/answer-2025-06-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of George Scott" src="images/answer-2025-06-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         George Scott "The Boomer"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was an eight-time Gold Glove Award winner at first base.
         </li>
-        <li>
+<li>
          Co-led the American League in home runs and led in runs batted in during the 1975 season.
         </li>
-        <li>
+<li>
          Was a three-time American League All-Star.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            36.5
           </td>
-          <td>
+<td>
            7433
           </td>
-          <td>
+<td>
            1992
           </td>
-          <td>
+<td>
            271
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            957
           </td>
-          <td>
+<td>
            1051
           </td>
-          <td>
+<td>
            69
           </td>
-          <td>
+<td>
            .333
           </td>
-          <td>
+<td>
            .435
           </td>
-          <td>
+<td>
            .767
           </td>
-          <td>
+<td>
            114
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979"];
             const warData = [3.4, 4.4, -2.8, 2.3, 1.7, 2.9, 4.9, 6.7, 4.2, 3.2, 3.6, 2.4, -0.2, -0.1];
             const teamsByYear = ["BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "MIL", "MIL", "MIL", "MIL", "MIL", "BOS", "BOS", "3TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "MIL", "BOS", "KCR"], "years": ["1972", "1967", "1975", "1971", "1976", "1978", "1966", "1977", "1968", "1970", "1974", "1979", "1969", "1973"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "George Scott", "hints": ["Was an eight-time Gold Glove Award winner at first base.", "Co-led the American League in home runs and led in runs batted in during the 1975 season.", "Was a three-time American League All-Star."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-13.html
+++ b/2025-06-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is George Scott.">
   <title>
    George Scott Answer - June 13, 2025 | Name That Yankee
   </title>

--- a/2025-06-15.html
+++ b/2025-06-15.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-15" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-15" rel="canonical"/><meta content="Discover the career highlights and statistics for Clay Bellinger, the featured New York Yankee for the 2025-06-15 trivia puzzle." name="description"/>
+
+<title>
    Clay Bellinger Answer - June 15, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 15, 2025: Clay Bellinger. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 15, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-15.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 15, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-15.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 15, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-15.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 15, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-15.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-15"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 15, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Clay Bellinger" src="images/answer-2025-06-15.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Clay Bellinger" src="images/answer-2025-06-15.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Clay Bellinger
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won two World Series championships with the New York Yankees.
         </li>
-        <li>
+<li>
          Played every defensive position except pitcher and catcher in a major league career.
         </li>
-        <li>
+<li>
          Father of Cody Bellinger, the 2017 National League Rookie of the Year and 2019 National League MVP.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -0.2
           </td>
-          <td>
+<td>
            311
           </td>
-          <td>
+<td>
            60
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            .193
           </td>
-          <td>
+<td>
            57
           </td>
-          <td>
+<td>
            35
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            .257
           </td>
-          <td>
+<td>
            .363
           </td>
-          <td>
+<td>
            .621
           </td>
-          <td>
+<td>
            58
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-15.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-15.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1999", "2000", "2001", "2002"];
             const warData = [0.1, 0.2, -0.5, 0.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "ANA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["ANA", "NYY"], "years": ["2001", "2002", "1999", "2000"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Clay Bellinger", "hints": ["Won two World Series championships with the New York Yankees.", "Played every defensive position except pitcher and catcher in a major league career.", "Father of Cody Bellinger, the 2017 National League Rookie of the Year and 2019 National League MVP."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-15.html
+++ b/2025-06-15.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-15" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Clay Bellinger.">
   <title>
    Clay Bellinger Answer - June 15, 2025 | Name That Yankee
   </title>

--- a/2025-06-16.html
+++ b/2025-06-16.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-16" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-16" rel="canonical"/><meta content="Discover the career highlights and statistics for Austin Romine, the featured New York Yankee for the 2025-06-16 trivia puzzle." name="description"/>
+
+<title>
    Austin Romine Answer - June 16, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 16, 2025: Austin Romine. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 16, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-16.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 16, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-16.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 16, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-16.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 16, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-16.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-16"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 16, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Austin Romine" src="images/answer-2025-06-16.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Austin Romine" src="images/answer-2025-06-16.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Austin Romine
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Father, Kevin, was an outfielder for the Boston Red Sox from 1985 to 1991.
         </li>
-        <li>
+<li>
          Was a teammate of brother, Andrew, on the 2020 Detroit Tigers.
         </li>
-        <li>
+<li>
          Pitched in eight career Major League games as a position player.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -1.3
           </td>
-          <td>
+<td>
            1352
           </td>
-          <td>
+<td>
            311
           </td>
-          <td>
+<td>
            31
           </td>
-          <td>
+<td>
            .230
           </td>
-          <td>
+<td>
            141
           </td>
-          <td>
+<td>
            166
           </td>
-          <td>
+<td>
            4
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            .348
           </td>
-          <td>
+<td>
            .616
           </td>
-          <td>
+<td>
            65
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-16.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-16.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2011", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022"];
             const warData = [-0.2, -0.5, -0.1, -0.2, -0.2, -1.0, 1.4, 0.7, -0.2, -0.3, -0.7];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "DET", "CHC", "3TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CIN", "2TM", "STL", "LAA", "NYY", "DET", "CHC"], "years": ["2016", "2015", "2018", "2019", "2020", "2022", "2021", "2013", "2017", "2011", "2014"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Austin Romine", "hints": ["Father, Kevin, was an outfielder for the Boston Red Sox from 1985 to 1991.", "Was a teammate of brother, Andrew, on the 2020 Detroit Tigers.", "Pitched in eight career Major League games as a position player."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-16.html
+++ b/2025-06-16.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-16" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Austin Romine.">
   <title>
    Austin Romine Answer - June 16, 2025 | Name That Yankee
   </title>

--- a/2025-06-17.html
+++ b/2025-06-17.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-17" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-17" rel="canonical"/><meta content="Discover the career highlights and statistics for Aaron Hicks, the featured New York Yankee for the 2025-06-17 trivia puzzle." name="description"/>
+
+<title>
    Aaron Hicks Answer - June 17, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 17, 2025: Aaron Hicks. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 17, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-17.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 17, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-17.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 17, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-17.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 17, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-17.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-17"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 17, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Aaron Hicks" src="images/answer-2025-06-17.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Aaron Hicks" src="images/answer-2025-06-17.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Aaron Hicks "A-A-Ron"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Recorded a 105.5 mph outfield throw in 2016, a Statcast record at the time.
         </li>
-        <li>
+<li>
          Tied the New York Yankees single-season record with three inside-the-park home runs in 2018.
         </li>
-        <li>
+<li>
          Is the son-in-law of former MLB manager Joe Maddon.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            13.2
           </td>
-          <td>
+<td>
            3135
           </td>
-          <td>
+<td>
            724
           </td>
-          <td>
+<td>
            109
           </td>
-          <td>
+<td>
            .231
           </td>
-          <td>
+<td>
            469
           </td>
-          <td>
+<td>
            392
           </td>
-          <td>
+<td>
            71
           </td>
-          <td>
+<td>
            .330
           </td>
-          <td>
+<td>
            .383
           </td>
-          <td>
+<td>
            .713
           </td>
-          <td>
+<td>
            96
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-17.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-17.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"];
             const warData = [0.7, 0.4, 1.4, -0.2, 3.9, 4.3, 1.3, 0.7, -0.3, 1.3, 0.5, -0.7];
             const teamsByYear = ["MIN", "MIN", "MIN", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "LAA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "LAA", "BAL", "MIN"], "years": ["2015", "2014", "2018", "2019", "2020", "2016", "2021", "2024", "2023", "2022", "2013", "2017"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Aaron Hicks", "hints": ["Recorded a 105.5 mph outfield throw in 2016, a Statcast record at the time.", "Tied the New York Yankees single-season record with three inside-the-park home runs in 2018.", "Is the son-in-law of former MLB manager Joe Maddon."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-17.html
+++ b/2025-06-17.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-17" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Aaron Hicks.">
   <title>
    Aaron Hicks Answer - June 17, 2025 | Name That Yankee
   </title>

--- a/2025-06-18.html
+++ b/2025-06-18.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-18" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-18" rel="canonical"/><meta content="Discover the career highlights and statistics for Andrew Heaney, the featured New York Yankee for the 2025-06-18 trivia puzzle." name="description"/>
+
+<title>
    Andrew Heaney Answer - June 18, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 18, 2025: Andrew Heaney. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 18, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-18.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 18, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-18.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 18, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-18.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 18, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-18.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-18"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 18, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Andrew Heaney" src="images/answer-2025-06-18.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Andrew Heaney" src="images/answer-2025-06-18.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Andrew Heaney
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was traded twice on the same day in December 2014.
         </li>
-        <li>
+<li>
          Won a World Series with the Texas Rangers in 2023.
         </li>
-        <li>
+<li>
          Tied an MLB record by allowing four consecutive home runs in a 2023 game.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            8.3
           </td>
-          <td>
+<td>
            56
           </td>
-          <td>
+<td>
            71
           </td>
-          <td>
+<td>
            4.50
           </td>
-          <td>
+<td>
            225
           </td>
-          <td>
+<td>
            206
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            1124.2
           </td>
-          <td>
+<td>
            1149
           </td>
-          <td>
+<td>
            1.269
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-18.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-18.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [-0.2, 1.9, 0.0, -0.4, 2.0, 1.3, 1.2, 0.3, 0.5, 1.0, 0.7, 0.2];
             const teamsByYear = ["MIA", "LAA", "LAA", "LAA", "LAA", "LAA", "LAA", "2TM", "LAD", "TEX", "TEX", "PIT"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "LAA", "PIT", "NYY", "MIA", "TEX"], "years": ["2016", "2015", "2024", "2018", "2019", "2020", "2022", "2021", "2023", "2017", "2025", "2014"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Andrew Heaney", "hints": ["Was traded twice on the same day in December 2014.", "Won a World Series with the Texas Rangers in 2023.", "Tied an MLB record by allowing four consecutive home runs in a 2023 game."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-18.html
+++ b/2025-06-18.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-18" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Andrew Heaney.">
   <title>
    Andrew Heaney Answer - June 18, 2025 | Name That Yankee
   </title>

--- a/2025-06-19.html
+++ b/2025-06-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jim Abbott.">
   <title>
    Jim Abbott Answer - June 19, 2025 | Name That Yankee
   </title>

--- a/2025-06-19.html
+++ b/2025-06-19.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Jim Abbott, the featured New York Yankee for the 2025-06-19 trivia puzzle." name="description"/>
+
+<title>
    Jim Abbott Answer - June 19, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 19, 2025: Jim Abbott. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 19, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 19, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-19.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 19, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 19, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-19.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-19"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 19, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jim Abbott" src="images/answer-2025-06-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jim Abbott" src="images/answer-2025-06-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jim Abbott
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched a no-hitter for the New York Yankees on September 4, 1993.
         </li>
-        <li>
+<li>
          Finished third in the 1991 American League Cy Young Award voting.
         </li>
-        <li>
+<li>
          Collected two hits in 21 career at-bats while playing in the National League.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            19.6
           </td>
-          <td>
+<td>
            87
           </td>
-          <td>
+<td>
            108
           </td>
-          <td>
+<td>
            4.25
           </td>
-          <td>
+<td>
            263
           </td>
-          <td>
+<td>
            254
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            1674.0
           </td>
-          <td>
+<td>
            888
           </td>
-          <td>
+<td>
            1.433
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1998", "1999"];
             const warData = [0.4, 1.4, 7.6, 5.7, 1.6, 1.8, 3.9, -2.1, 0.5, -1.1];
             const teamsByYear = ["CAL", "CAL", "CAL", "CAL", "NYY", "NYY", "2TM", "CAL", "CHW", "MIL"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CAL", "CHW", "NYY", "MIL"], "years": ["1992", "1993", "1990", "1994", "1991", "1989", "1999", "1995", "1998", "1996"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jim Abbott", "hints": ["Pitched a no-hitter for the New York Yankees on September 4, 1993.", "Finished third in the 1991 American League Cy Young Award voting.", "Collected two hits in 21 career at-bats while playing in the National League."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-20.html
+++ b/2025-06-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Eddie Lopat.">
   <title>
    Eddie Lopat Answer - June 20, 2025 | Name That Yankee
   </title>

--- a/2025-06-20.html
+++ b/2025-06-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-20" rel="canonical"/><meta content="Discover the career highlights and statistics for Eddie Lopat, the featured New York Yankee for the 2025-06-20 trivia puzzle." name="description"/>
+
+<title>
    Eddie Lopat Answer - June 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 20, 2025: Eddie Lopat. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Eddie Lopat" src="images/answer-2025-06-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Eddie Lopat" src="images/answer-2025-06-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Eddie Lopat "The Junkman"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won five consecutive World Series championships from 1949 to 1953.
         </li>
-        <li>
+<li>
          Led the American League in ERA in 1953 with a 2.42 mark.
         </li>
-        <li>
+<li>
          Posted a 4-1 record and a 2.60 ERA across five World Series appearances.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            32.1
           </td>
-          <td>
+<td>
            166
           </td>
-          <td>
+<td>
            112
           </td>
-          <td>
+<td>
            3.21
           </td>
-          <td>
+<td>
            340
           </td>
-          <td>
+<td>
            318
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            2439.1
           </td>
-          <td>
+<td>
            859
           </td>
-          <td>
+<td>
            1.277
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1944", "1945", "1946", "1947", "1948", "1949", "1950", "1951", "1952", "1953", "1954", "1955"];
             const warData = [1.3, -0.2, 4.0, 5.5, 2.2, 2.6, 3.1, 3.6, 2.2, 3.1, 1.0, -0.2];
             const teamsByYear = ["CHW", "CHW", "CHW", "CHW", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW", "BAL"], "years": ["1947", "1950", "1955", "1944", "1949", "1948", "1946", "1945", "1952", "1954", "1953", "1951"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Eddie Lopat", "hints": ["Won five consecutive World Series championships from 1949 to 1953.", "Led the American League in ERA in 1953 with a 2.42 mark.", "Posted a 4-1 record and a 2.60 ERA across five World Series appearances."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-21.html
+++ b/2025-06-21.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-21" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is George Stirnweiss.">
   <title>
    George Stirnweiss Answer - June 21, 2025 | Name That Yankee
   </title>

--- a/2025-06-21.html
+++ b/2025-06-21.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-21" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-21" rel="canonical"/><meta content="Discover the career highlights and statistics for George Stirnweiss, the featured New York Yankee for the 2025-06-21 trivia puzzle." name="description"/>
+
+<title>
    George Stirnweiss Answer - June 21, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 21, 2025: George Stirnweiss. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 21, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-21.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 21, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-21.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 21, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-21.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 21, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-21.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-21"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 21, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of George Stirnweiss" src="images/answer-2025-06-21.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of George Stirnweiss" src="images/answer-2025-06-21.webp"/>
+</div>
+<div class="player-info">
+<h2>
         George Stirnweiss "Snuffy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1945 American League batting title with a .309 average.
         </li>
-        <li>
+<li>
          Led the American League in hits, runs, triples, and stolen bases in 1945.
         </li>
-        <li>
+<li>
          Was an All-American halfback in college football at the University of North Carolina.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.5
           </td>
-          <td>
+<td>
            3695
           </td>
-          <td>
+<td>
            989
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            .268
           </td>
-          <td>
+<td>
            604
           </td>
-          <td>
+<td>
            281
           </td>
-          <td>
+<td>
            134
           </td>
-          <td>
+<td>
            .362
           </td>
-          <td>
+<td>
            .371
           </td>
-          <td>
+<td>
            .733
           </td>
-          <td>
+<td>
            103
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-21.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-21.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1943", "1944", "1945", "1946", "1947", "1948", "1949", "1950", "1951", "1952"];
             const warData = [1.4, 8.6, 8.8, 3.0, 3.7, 2.7, 0.6, -2.0, 0.6, 0.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "CLE", "CLE"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "SLB", "CLE"], "years": ["1943", "1947", "1950", "1944", "1949", "1948", "1946", "1945", "1952", "1951"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "George Stirnweiss", "hints": ["Won the 1945 American League batting title with a .309 average.", "Led the American League in hits, runs, triples, and stolen bases in 1945.", "Was an All-American halfback in college football at the University of North Carolina."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-23.html
+++ b/2025-06-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul O'Neill.">
   <title>
    Paul O'Neill Answer - June 23, 2025 | Name That Yankee
   </title>

--- a/2025-06-23.html
+++ b/2025-06-23.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul O'Neill, the featured New York Yankee for the 2025-06-23 trivia puzzle." name="description"/>
+
+<title>
    Paul O'Neill Answer - June 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 23, 2025: Paul O'Neill. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul O'Neill" src="images/answer-2025-06-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul O'Neill" src="images/answer-2025-06-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul O'Neill "The Warrior"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1994 American League batting title.
         </li>
-        <li>
+<li>
          Won five World Series championships with two different teams.
         </li>
-        <li>
+<li>
          Was on the field for three different perfect games.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            38.8
           </td>
-          <td>
+<td>
            7318
           </td>
-          <td>
+<td>
            2105
           </td>
-          <td>
+<td>
            281
           </td>
-          <td>
+<td>
            .288
           </td>
-          <td>
+<td>
            1041
           </td>
-          <td>
+<td>
            1269
           </td>
-          <td>
+<td>
            141
           </td>
-          <td>
+<td>
            .363
           </td>
-          <td>
+<td>
            .470
           </td>
-          <td>
+<td>
            .833
           </td>
-          <td>
+<td>
            120
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1985", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [0.0, 0.6, 2.2, 2.6, 0.3, 4.9, 1.6, 2.9, 4.3, 2.8, 3.9, 2.4, 5.8, 2.8, 1.3, 0.5];
             const teamsByYear = ["CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CIN"], "years": ["1992", "2000", "1993", "1990", "1985", "1994", "1987", "1991", "1989", "1999", "2001", "1997", "1995", "1998", "1996", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul O'Neill", "hints": ["Won the 1994 American League batting title.", "Won five World Series championships with two different teams.", "Was on the field for three different perfect games."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-24.html
+++ b/2025-06-24.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-24" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mariano Duncan.">
   <title>
    Mariano Duncan Answer - June 24, 2025 | Name That Yankee
   </title>

--- a/2025-06-24.html
+++ b/2025-06-24.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-24" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-24" rel="canonical"/><meta content="Discover the career highlights and statistics for Mariano Duncan, the featured New York Yankee for the 2025-06-24 trivia puzzle." name="description"/>
+
+<title>
    Mariano Duncan Answer - June 24, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 24, 2025: Mariano Duncan. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 24, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-24.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 24, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-24.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 24, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-24.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 24, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-24.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-24"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 24, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mariano Duncan" src="images/answer-2025-06-24.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mariano Duncan" src="images/answer-2025-06-24.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mariano Duncan
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a National League All-Star in 1994.
         </li>
-        <li>
+<li>
          Won a World Series with the Cincinnati Reds in 1990 and the New York Yankees in 1996.
         </li>
-        <li>
+<li>
          Hit the first home run in the history of the Florida Marlins' home ballpark on April 5, 1993.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            5.8
           </td>
-          <td>
+<td>
            4677
           </td>
-          <td>
+<td>
            1247
           </td>
-          <td>
+<td>
            87
           </td>
-          <td>
+<td>
            .267
           </td>
-          <td>
+<td>
            619
           </td>
-          <td>
+<td>
            491
           </td>
-          <td>
+<td>
            174
           </td>
-          <td>
+<td>
            .300
           </td>
-          <td>
+<td>
            .388
           </td>
-          <td>
+<td>
            .688
           </td>
-          <td>
+<td>
            86
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-24.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-24.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1985", "1986", "1987", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997"];
             const warData = [1.8, -0.1, -0.6, -0.6, 2.5, -0.3, 1.1, 0.1, 0.5, -0.1, 2.7, -1.1];
             const teamsByYear = ["LAD", "LAD", "LAD", "2TM", "CIN", "CIN", "PHI", "PHI", "PHI", "2TM", "NYY", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PHI", "NYY", "LAD", "CIN", "TOR"], "years": ["1995", "1992", "1987", "1996", "1997", "1989", "1985", "1986", "1990", "1991", "1994", "1993"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mariano Duncan", "hints": ["Was a National League All-Star in 1994.", "Won a World Series with the Cincinnati Reds in 1990 and the New York Yankees in 1996.", "Hit the first home run in the history of the Florida Marlins' home ballpark on April 5, 1993."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-25.html
+++ b/2025-06-25.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-25" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-25" rel="canonical"/><meta content="Discover the career highlights and statistics for Ken Griffey Sr., the featured New York Yankee for the 2025-06-25 trivia puzzle." name="description"/>
+
+<title>
    Ken Griffey Sr. Answer - June 25, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 25, 2025: Ken Griffey Sr.. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 25, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-25.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 25, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-25.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 25, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-25.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 25, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-25.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-25"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 25, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ken Griffey Sr." src="images/answer-2025-06-25.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ken Griffey Sr." src="images/answer-2025-06-25.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ken Griffey Sr.
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was part of the first father-son duo to play as teammates in an MLB game.
         </li>
-        <li>
+<li>
          Hit back-to-back home runs with a son in 1990.
         </li>
-        <li>
+<li>
          Was the 1980 All-Star Game MVP.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            34.5
           </td>
-          <td>
+<td>
            7229
           </td>
-          <td>
+<td>
            2143
           </td>
-          <td>
+<td>
            152
           </td>
-          <td>
+<td>
            .296
           </td>
-          <td>
+<td>
            1129
           </td>
-          <td>
+<td>
            859
           </td>
-          <td>
+<td>
            200
           </td>
-          <td>
+<td>
            .359
           </td>
-          <td>
+<td>
            .431
           </td>
-          <td>
+<td>
            .790
           </td>
-          <td>
+<td>
            118
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-25.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-25.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [0.9, 0.6, 3.1, 4.6, 4.2, 2.6, 2.5, 3.9, 2.8, 0.6, 2.5, 0.5, 2.1, 2.2, 1.4, -1.3, 0.6, 0.5, 0.3];
             const teamsByYear = ["CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "NYY", "NYY", "NYY", "NYY", "2TM", "ATL", "2TM", "CIN", "2TM", "SEA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CIN", "ATL", "SEA"], "years": ["1990", "1977", "1979", "1982", "1987", "1980", "1981", "1975", "1988", "1973", "1983", "1974", "1976", "1986", "1985", "1978", "1991", "1989", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ken Griffey Sr.", "hints": ["Was part of the first father-son duo to play as teammates in an MLB game.", "Hit back-to-back home runs with a son in 1990.", "Was the 1980 All-Star Game MVP."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-25.html
+++ b/2025-06-25.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-25" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ken Griffey Sr..">
   <title>
    Ken Griffey Sr. Answer - June 25, 2025 | Name That Yankee
   </title>

--- a/2025-06-27.html
+++ b/2025-06-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Greg Cadaret.">
   <title>
    Greg Cadaret Answer - June 27, 2025 | Name That Yankee
   </title>

--- a/2025-06-27.html
+++ b/2025-06-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Greg Cadaret, the featured New York Yankee for the 2025-06-27 trivia puzzle." name="description"/>
+
+<title>
    Greg Cadaret Answer - June 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 27, 2025: Greg Cadaret. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Greg Cadaret" src="images/answer-2025-06-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Greg Cadaret" src="images/answer-2025-06-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Greg Cadaret "The Caddy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was traded to the New York Yankees as part of the package for Rickey Henderson in 1989.
         </li>
-        <li>
+<li>
          Pitched 10 scoreless innings across four postseason series in 1988 and 1989.
         </li>
-        <li>
+<li>
          Pitched for eight different major league teams during a ten-year career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.6
           </td>
-          <td>
+<td>
            38
           </td>
-          <td>
+<td>
            32
           </td>
-          <td>
+<td>
            3.99
           </td>
-          <td>
+<td>
            451
           </td>
-          <td>
+<td>
            35
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            724.1
           </td>
-          <td>
+<td>
            539
           </td>
-          <td>
+<td>
            1.545
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1997", "1998"];
             const warData = [0.2, 1.1, 0.3, 0.3, 2.2, 0.6, 0.3, 0.4, 0.3, 1.0];
             const teamsByYear = ["OAK", "OAK", "2TM", "NYY", "NYY", "NYY", "2TM", "2TM", "ANA", "2TM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["OAK", "ANA", "NYY", "DET", "CIN", "TOR", "KCR", "TEX"], "years": ["1992", "1993", "1990", "1994", "1987", "1991", "1989", "1997", "1998", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Greg Cadaret", "hints": ["Was traded to the New York Yankees as part of the package for Rickey Henderson in 1989.", "Pitched 10 scoreless innings across four postseason series in 1988 and 1989.", "Pitched for eight different major league teams during a ten-year career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-28.html
+++ b/2025-06-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Al Downing.">
   <title>
    Al Downing Answer - June 28, 2025 | Name That Yankee
   </title>

--- a/2025-06-28.html
+++ b/2025-06-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Al Downing, the featured New York Yankee for the 2025-06-28 trivia puzzle." name="description"/>
+
+<title>
    Al Downing Answer - June 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 28, 2025: Al Downing. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Al Downing" src="images/answer-2025-06-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Al Downing" src="images/answer-2025-06-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Al Downing
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Gave up Hank Aaron's record-breaking 715th career home run.
         </li>
-        <li>
+<li>
          Was the 1971 National League Comeback Player of the Year.
         </li>
-        <li>
+<li>
          Led the American League in strikeouts in 1964.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            21.0
           </td>
-          <td>
+<td>
            123
           </td>
-          <td>
+<td>
            107
           </td>
-          <td>
+<td>
            3.22
           </td>
-          <td>
+<td>
            405
           </td>
-          <td>
+<td>
            317
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            2268.1
           </td>
-          <td>
+<td>
            1639
           </td>
-          <td>
+<td>
            1.269
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977"];
             const warData = [-0.2, 0.0, 3.8, 2.4, 2.2, 1.4, 4.5, 0.3, 1.0, 0.9, 3.8, 2.0, 1.0, -0.5, 0.1, 0.2, -0.4];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "LAD", "LAD", "LAD", "LAD", "LAD", "LAD", "LAD"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "NYY", "OAK", "MIL"], "years": ["1971", "1969", "1975", "1977", "1967", "1968", "1973", "1974", "1965", "1976", "1970", "1964", "1961", "1962", "1966", "1963", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Al Downing", "hints": ["Gave up Hank Aaron's record-breaking 715th career home run.", "Was the 1971 National League Comeback Player of the Year.", "Led the American League in strikeouts in 1964."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-29.html
+++ b/2025-06-29.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-29" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Steve Sax.">
   <title>
    Steve Sax Answer - June 29, 2025 | Name That Yankee
   </title>

--- a/2025-06-29.html
+++ b/2025-06-29.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-29" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-29" rel="canonical"/><meta content="Discover the career highlights and statistics for Steve Sax, the featured New York Yankee for the 2025-06-29 trivia puzzle." name="description"/>
+
+<title>
    Steve Sax Answer - June 29, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 29, 2025: Steve Sax. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 29, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-29.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 29, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-29.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 29, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-29.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 29, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-29.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-06-29"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 29, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Steve Sax" src="images/answer-2025-06-29.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Steve Sax" src="images/answer-2025-06-29.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Steve Sax
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1982 National League Rookie of the Year award.
         </li>
-        <li>
+<li>
          Was a teammate of brother Dave Sax on the Los Angeles Dodgers from 1982 to 1983.
         </li>
-        <li>
+<li>
          Led all American League second basemen in fielding percentage in 1989.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            25.7
           </td>
-          <td>
+<td>
            6940
           </td>
-          <td>
+<td>
            1949
           </td>
-          <td>
+<td>
            54
           </td>
-          <td>
+<td>
            .281
           </td>
-          <td>
+<td>
            913
           </td>
-          <td>
+<td>
            550
           </td>
-          <td>
+<td>
            444
           </td>
-          <td>
+<td>
            .335
           </td>
-          <td>
+<td>
            .358
           </td>
-          <td>
+<td>
            .692
           </td>
-          <td>
+<td>
            95
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-29.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-29.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994"];
             const warData = [0.7, 3.3, 1.7, 1.2, 1.3, 4.9, 0.8, 2.1, 4.4, 1.4, 4.2, 0.1, -0.3, 0.0];
             const teamsByYear = ["LAD", "LAD", "LAD", "LAD", "LAD", "LAD", "LAD", "LAD", "NYY", "NYY", "NYY", "CHW", "CHW", "OAK"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW", "LAD", "OAK"], "years": ["1992", "1986", "1993", "1990", "1982", "1985", "1994", "1987", "1983", "1991", "1989", "1981", "1984", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Steve Sax", "hints": ["Won the 1982 National League Rookie of the Year award.", "Was a teammate of brother Dave Sax on the Los Angeles Dodgers from 1982 to 1983.", "Led all American League second basemen in fielding percentage in 1989."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-06-30.html
+++ b/2025-06-30.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-06-30" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Roger Clemens.">
   <title>
    Roger Clemens Answer - June 30, 2025 | Name That Yankee
   </title>

--- a/2025-06-30.html
+++ b/2025-06-30.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-06-30" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-06-30" rel="canonical"/><meta content="Discover the career highlights and statistics for Roger Clemens, the featured New York Yankee for the 2025-06-30 trivia puzzle." name="description"/>
+
+<title>
    Roger Clemens Answer - June 30, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on June 30, 2025: Roger Clemens. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - June 30, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-06-30.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - June 30, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-06-30.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - June 30, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-06-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - June 30, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-06-30.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-06-30"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for June 30, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Roger Clemens" src="images/answer-2025-06-30.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Roger Clemens" src="images/answer-2025-06-30.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Roger Clemens "Rocket"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a record seven Cy Young Awards.
         </li>
-        <li>
+<li>
          Was the first pitcher to record two 20-strikeout games.
         </li>
-        <li>
+<li>
          Won both the American League Cy Young and Most Valuable Player awards in 1986.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            139.2
           </td>
-          <td>
+<td>
            354
           </td>
-          <td>
+<td>
            184
           </td>
-          <td>
+<td>
            3.12
           </td>
-          <td>
+<td>
            709
           </td>
-          <td>
+<td>
            707
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            4916.2
           </td>
-          <td>
+<td>
            4672
           </td>
-          <td>
+<td>
            1.173
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-06-30.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-06-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007"];
             const warData = [1.8, 2.7, 8.8, 9.4, 7.1, 5.7, 10.4, 7.9, 8.7, 2.6, 6.0, 1.9, 7.7, 11.9, 8.1, 2.8, 4.6, 5.7, 2.6, 4.0, 5.4, 7.8, 3.5, 1.5];
             const teamsByYear = ["BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "TOR", "TOR", "NYY", "NYY", "NYY", "NYY", "NYY", "HOU", "HOU", "HOU", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "TOR", "HOU", "BOS"], "years": ["2000", "1990", "2003", "2005", "1992", "1987", "2004", "1995", "1984", "1988", "2006", "1993", "2007", "2002", "1997", "1996", "1986", "1985", "1994", "1991", "1989", "2001", "1999", "1998"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Roger Clemens", "hints": ["Won a record seven Cy Young Awards.", "Was the first pitcher to record two 20-strikeout games.", "Won both the American League Cy Young and Most Valuable Player awards in 1986."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-01.html
+++ b/2025-07-01.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-01" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul Quantrill.">
   <title>
    Paul Quantrill Answer - July 01, 2025 | Name That Yankee
   </title>

--- a/2025-07-01.html
+++ b/2025-07-01.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-01" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-01" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul Quantrill, the featured New York Yankee for the 2025-07-01 trivia puzzle." name="description"/>
+
+<title>
    Paul Quantrill Answer - July 01, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 01, 2025: Paul Quantrill. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 01, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-01.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 01, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-01.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 01, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-01.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 01, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-01.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-01"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 01, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul Quantrill" src="images/answer-2025-07-01.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul Quantrill" src="images/answer-2025-07-01.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul Quantrill "Q"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Led the league in games pitched for four consecutive seasons from 2001-2004.
         </li>
-        <li>
+<li>
          Was an American League All-Star in 2001.
         </li>
-        <li>
+<li>
          Father of MLB pitcher Cal Quantrill.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            17.8
           </td>
-          <td>
+<td>
            68
           </td>
-          <td>
+<td>
            78
           </td>
-          <td>
+<td>
            3.83
           </td>
-          <td>
+<td>
            841
           </td>
-          <td>
+<td>
            64
           </td>
-          <td>
+<td>
            21
           </td>
-          <td>
+<td>
            1255.2
           </td>
-          <td>
+<td>
            725
           </td>
-          <td>
+<td>
            1.416
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-01.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-01.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005"];
             const warData = [1.3, 1.0, 0.2, 0.6, 0.6, 3.2, 2.8, 1.3, 0.9, 2.4, 1.1, 2.3, 0.8, -0.2];
             const teamsByYear = ["BOS", "BOS", "2TM", "PHI", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "LAD", "LAD", "NYY", "3TM"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PHI", "LAD", "2TM", "FLA", "BOS", "NYY", "TOR", "SDP"], "years": ["2005", "1992", "2000", "1993", "1994", "2004", "1999", "2001", "2002", "1997", "1995", "1998", "2003", "1996"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul Quantrill", "hints": ["Led the league in games pitched for four consecutive seasons from 2001-2004.", "Was an American League All-Star in 2001.", "Father of MLB pitcher Cal Quantrill."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-02.html
+++ b/2025-07-02.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-02" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-02" rel="canonical"/><meta content="Discover the career highlights and statistics for Jesse Barfield, the featured New York Yankee for the 2025-07-02 trivia puzzle." name="description"/>
+
+<title>
    Jesse Barfield Answer - July 02, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 02, 2025: Jesse Barfield. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 02, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-02.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 02, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-02.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 02, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-02.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 02, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-02.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-02"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 02, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jesse Barfield" src="images/answer-2025-07-02.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jesse Barfield" src="images/answer-2025-07-02.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jesse Barfield
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Led the American League with 40 home runs in 1986.
         </li>
-        <li>
+<li>
          Led all American League outfielders in assists for three consecutive seasons from 1985-1987.
         </li>
-        <li>
+<li>
          Father of two sons, Josh and Jeremy, who both also played in Major League Baseball.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            39.4
           </td>
-          <td>
+<td>
            4759
           </td>
-          <td>
+<td>
            1219
           </td>
-          <td>
+<td>
            241
           </td>
-          <td>
+<td>
            .256
           </td>
-          <td>
+<td>
            715
           </td>
-          <td>
+<td>
            716
           </td>
-          <td>
+<td>
            66
           </td>
-          <td>
+<td>
            .335
           </td>
-          <td>
+<td>
            .466
           </td>
-          <td>
+<td>
            .802
           </td>
-          <td>
+<td>
            117
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-02.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-02.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992"];
             const warData = [0.5, 1.1, 2.8, 2.8, 6.9, 7.6, 4.7, 2.9, 4.4, 5.2, 1.9, -1.3];
             const teamsByYear = ["TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "2TM", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "TOR"], "years": ["1992", "1986", "1990", "1982", "1985", "1987", "1983", "1991", "1989", "1981", "1984", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jesse Barfield", "hints": ["Led the American League with 40 home runs in 1986.", "Led all American League outfielders in assists for three consecutive seasons from 1985-1987.", "Father of two sons, Josh and Jeremy, who both also played in Major League Baseball."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-02.html
+++ b/2025-07-02.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-02" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jesse Barfield.">
   <title>
    Jesse Barfield Answer - July 02, 2025 | Name That Yankee
   </title>

--- a/2025-07-03.html
+++ b/2025-07-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-03" rel="canonical"/><meta content="Discover the career highlights and statistics for Lyle Overbay, the featured New York Yankee for the 2025-07-03 trivia puzzle." name="description"/>
+
+<title>
    Lyle Overbay Answer - July 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 03, 2025: Lyle Overbay. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Lyle Overbay" src="images/answer-2025-07-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Lyle Overbay" src="images/answer-2025-07-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Lyle Overbay
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Led the American League with 53 doubles in 2004.
         </li>
-        <li>
+<li>
          Hit for the cycle on July 5, 2009.
         </li>
-        <li>
+<li>
          Led all American League first basemen in assists in 2006 and 2008.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            16.3
           </td>
-          <td>
+<td>
            5102
           </td>
-          <td>
+<td>
            1355
           </td>
-          <td>
+<td>
            151
           </td>
-          <td>
+<td>
            .266
           </td>
-          <td>
+<td>
            645
           </td>
-          <td>
+<td>
            675
           </td>
-          <td>
+<td>
            19
           </td>
-          <td>
+<td>
            .347
           </td>
-          <td>
+<td>
            .429
           </td>
-          <td>
+<td>
            .776
           </td>
-          <td>
+<td>
            106
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014"];
             const warData = [1.0, 1.6, 2.7, 3.3, 1.1, 2.6, 2.9, 2.5, -0.5, -0.1, 0.0, -0.6];
             const teamsByYear = ["ARI", "MIL", "MIL", "TOR", "TOR", "TOR", "TOR", "TOR", "2TM", "2TM", "NYY", "MIL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["ARI", "PIT", "NYY", "ATL", "MIL", "TOR"], "years": ["2005", "2012", "2009", "2010", "2008", "2007", "2013", "2004", "2011", "2014", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Lyle Overbay", "hints": ["Led the American League with 53 doubles in 2004.", "Hit for the cycle on July 5, 2009.", "Led all American League first basemen in assists in 2006 and 2008."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-03.html
+++ b/2025-07-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Lyle Overbay.">
   <title>
    Lyle Overbay Answer - July 03, 2025 | Name That Yankee
   </title>

--- a/2025-07-04.html
+++ b/2025-07-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Neil Allen, the featured New York Yankee for the 2025-07-04 trivia puzzle." name="description"/>
+
+<title>
    Neil Allen Answer - July 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 04, 2025: Neil Allen. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Neil Allen" src="images/answer-2025-07-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Neil Allen" src="images/answer-2025-07-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Neil Allen
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was traded from the New York Mets to the St. Louis Cardinals for Keith Hernandez.
         </li>
-        <li>
+<li>
          Was a National League All-Star in 1981.
         </li>
-        <li>
+<li>
          Led the National League in games finished with 43 during the 1981 season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.9
           </td>
-          <td>
+<td>
            58
           </td>
-          <td>
+<td>
            70
           </td>
-          <td>
+<td>
            3.88
           </td>
-          <td>
+<td>
            434
           </td>
-          <td>
+<td>
            59
           </td>
-          <td>
+<td>
            75
           </td>
-          <td>
+<td>
            988.1
           </td>
-          <td>
+<td>
            611
           </td>
-          <td>
+<td>
            1.419
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989"];
             const warData = [0.5, 0.4, 1.0, 2.0, 0.9, 0.2, -0.8, 1.9, -0.5, 1.8, -0.3];
             const teamsByYear = ["NYM", "NYM", "NYM", "NYM", "2TM", "STL", "2TM", "CHW", "2TM", "NYY", "CLE"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYM", "STL", "NYY", "CHW", "CLE"], "years": ["1980", "1986", "1989", "1982", "1988", "1979", "1983", "1987", "1985", "1981", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Neil Allen", "hints": ["Was traded from the New York Mets to the St. Louis Cardinals for Keith Hernandez.", "Was a National League All-Star in 1981.", "Led the National League in games finished with 43 during the 1981 season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-04.html
+++ b/2025-07-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Neil Allen.">
   <title>
    Neil Allen Answer - July 04, 2025 | Name That Yankee
   </title>

--- a/2025-07-05.html
+++ b/2025-07-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Daryl Boston.">
   <title>
    Daryl Boston Answer - July 05, 2025 | Name That Yankee
   </title>

--- a/2025-07-05.html
+++ b/2025-07-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Daryl Boston, the featured New York Yankee for the 2025-07-05 trivia puzzle." name="description"/>
+
+<title>
    Daryl Boston Answer - July 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 05, 2025: Daryl Boston. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Daryl Boston" src="images/answer-2025-07-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Daryl Boston" src="images/answer-2025-07-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Daryl Boston
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the seventh overall pick in the 1981 MLB draft.
         </li>
-        <li>
+<li>
          Hit the first pinch-hit home run in Colorado Rockies franchise history.
         </li>
-        <li>
+<li>
          Served as the Chicago White Sox first base coach for 11 seasons.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.3
           </td>
-          <td>
+<td>
            2629
           </td>
-          <td>
+<td>
            655
           </td>
-          <td>
+<td>
            83
           </td>
-          <td>
+<td>
            .249
           </td>
-          <td>
+<td>
            378
           </td>
-          <td>
+<td>
            278
           </td>
-          <td>
+<td>
            98
           </td>
-          <td>
+<td>
            .312
           </td>
-          <td>
+<td>
            .410
           </td>
-          <td>
+<td>
            .722
           </td>
-          <td>
+<td>
            95
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994"];
             const warData = [-0.4, -0.1, 1.2, 0.7, 0.7, 0.5, 1.5, 0.8, 0.5, -0.5, -0.6];
             const teamsByYear = ["CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "2TM", "NYM", "NYM", "COL", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW", "COL", "NYM"], "years": ["1992", "1986", "1993", "1990", "1985", "1994", "1987", "1991", "1989", "1984", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Daryl Boston", "hints": ["Was the seventh overall pick in the 1981 MLB draft.", "Hit the first pinch-hit home run in Colorado Rockies franchise history.", "Served as the Chicago White Sox first base coach for 11 seasons."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-06.html
+++ b/2025-07-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Darryl Strawberry.">
   <title>
    Darryl Strawberry Answer - July 06, 2025 | Name That Yankee
   </title>

--- a/2025-07-06.html
+++ b/2025-07-06.html
@@ -1,24 +1,25 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Darryl Strawberry, the featured New York Yankee for the 2025-07-06 trivia puzzle." name="description"/>
+
+<title>
    Darryl Strawberry Answer - July 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 06, 2025: Darryl Strawberry. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+
+<meta content="Name That Yankee - July 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -40,202 +41,202 @@
   "datePublished": "2025-07-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Darryl Strawberry" src="images/answer-2025-07-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Darryl Strawberry" src="images/answer-2025-07-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Darryl Strawberry "Straw"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Is the all-time franchise leader in home runs for the New York Mets.
         </li>
-        <li>
+<li>
          Won World Series titles with both the New York Mets and the New York Yankees.
         </li>
-        <li>
+<li>
          Played for all four MLB teams that have been based in New York City: the Mets, Yankees, Dodgers, and Giants.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            42.2
           </td>
-          <td>
+<td>
            5418
           </td>
-          <td>
+<td>
            1401
           </td>
-          <td>
+<td>
            335
           </td>
-          <td>
+<td>
            .259
           </td>
-          <td>
+<td>
            898
           </td>
-          <td>
+<td>
            1000
           </td>
-          <td>
+<td>
            221
           </td>
-          <td>
+<td>
            .357
           </td>
-          <td>
+<td>
            .505
           </td>
-          <td>
+<td>
            .862
           </td>
-          <td>
+<td>
            138
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999"];
             const warData = [2.6, 2.8, 4.8, 3.4, 6.4, 5.4, 4.8, 6.3, 3.7, 0.2, -1.0, -0.2, 0.6, 0.4, -0.5, 1.5, 0.8];
             const teamsByYear = ["NYM", "NYM", "NYM", "NYM", "NYM", "NYM", "NYM", "NYM", "LAD", "LAD", "LAD", "SFG", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -356,26 +357,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "NYY", "SFG", "NYM"], "years": ["1984", "1987", "1986", "1991", "1988", "1989", "1992", "1996", "1995", "1997", "1983", "1999", "1998", "1994", "1990", "1993", "1985"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Darryl Strawberry", "hints": ["Is the all-time franchise leader in home runs for the New York Mets.", "Won World Series titles with both the New York Mets and the New York Yankees.", "Played for all four MLB teams that have been based in New York City: the Mets, Yankees, Dodgers, and Giants."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -386,11 +387,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-08.html
+++ b/2025-07-08.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-08" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jay Buhner.">
   <title>
    Jay Buhner Answer - July 08, 2025 | Name That Yankee
   </title>

--- a/2025-07-08.html
+++ b/2025-07-08.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-08" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-08" rel="canonical"/><meta content="Discover the career highlights and statistics for Jay Buhner, the featured New York Yankee for the 2025-07-08 trivia puzzle." name="description"/>
+
+<title>
    Jay Buhner Answer - July 08, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 08, 2025: Jay Buhner. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 08, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-08.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 08, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-08.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 08, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-08.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 08, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-08.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-08"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 08, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jay Buhner" src="images/answer-2025-07-08.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jay Buhner" src="images/answer-2025-07-08.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jay Buhner "Bone"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit 40 or more home runs in three consecutive seasons from 1995-1997.
         </li>
-        <li>
+<li>
          Won a Gold Glove Award as a right fielder in 1996.
         </li>
-        <li>
+<li>
          Was inducted into the Seattle Mariners Hall of Fame in 2004.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            23.0
           </td>
-          <td>
+<td>
            5013
           </td>
-          <td>
+<td>
            1273
           </td>
-          <td>
+<td>
            310
           </td>
-          <td>
+<td>
            .254
           </td>
-          <td>
+<td>
            797
           </td>
-          <td>
+<td>
            965
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            .359
           </td>
-          <td>
+<td>
            .494
           </td>
-          <td>
+<td>
            .852
           </td>
-          <td>
+<td>
            124
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-08.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-08.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [-0.1, 2.6, 1.6, 0.2, 0.6, 0.2, 2.5, 2.8, 2.4, 3.5, 3.3, 0.4, 0.8, 1.9, 0.1];
             const teamsByYear = ["NYY", "2TM", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "SEA"], "years": ["1992", "2000", "1993", "1990", "1994", "1987", "1991", "1989", "1999", "2001", "1997", "1995", "1998", "1996", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jay Buhner", "hints": ["Hit 40 or more home runs in three consecutive seasons from 1995-1997.", "Won a Gold Glove Award as a right fielder in 1996.", "Was inducted into the Seattle Mariners Hall of Fame in 2004."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-09.html
+++ b/2025-07-09.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-09" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jim Beattie.">
   <title>
    Jim Beattie Answer - July 09, 2025 | Name That Yankee
   </title>

--- a/2025-07-09.html
+++ b/2025-07-09.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-09" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-09" rel="canonical"/><meta content="Discover the career highlights and statistics for Jim Beattie, the featured New York Yankee for the 2025-07-09 trivia puzzle." name="description"/>
+
+<title>
    Jim Beattie Answer - July 09, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 09, 2025: Jim Beattie. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 09, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-09.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 09, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-09.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 09, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-09.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 09, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-09.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-09"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 09, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jim Beattie" src="images/answer-2025-07-09.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jim Beattie" src="images/answer-2025-07-09.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jim Beattie
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the winning pitcher in Game 1 of the 1978 World Series.
         </li>
-        <li>
+<li>
          Threw the first pitch in the history of the Hubert H. Humphrey Metrodome.
         </li>
-        <li>
+<li>
          Served as general manager for the Montreal Expos and Baltimore Orioles.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.8
           </td>
-          <td>
+<td>
            52
           </td>
-          <td>
+<td>
            87
           </td>
-          <td>
+<td>
            4.17
           </td>
-          <td>
+<td>
            203
           </td>
-          <td>
+<td>
            182
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            1148.2
           </td>
-          <td>
+<td>
            660
           </td>
-          <td>
+<td>
            1.423
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-09.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-09.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986"];
             const warData = [0.7, 0.2, 0.3, 1.8, 3.7, 4.3, 5.1, -1.4, 0.1];
             const teamsByYear = ["NYY", "NYY", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA", "SEA"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "SEA"], "years": ["1986", "1982", "1985", "1978", "1983", "1980", "1981", "1984", "1979"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jim Beattie", "hints": ["Was the winning pitcher in Game 1 of the 1978 World Series.", "Threw the first pitch in the history of the Hubert H. Humphrey Metrodome.", "Served as general manager for the Montreal Expos and Baltimore Orioles."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-10.html
+++ b/2025-07-10.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-10" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Luis Sojo, the featured New York Yankee for the 2025-07-10 trivia puzzle." name="description"/>
+
+<title>
    Luis Sojo Answer - July 10, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 10, 2025: Luis Sojo. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 10, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-10.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 10, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-10.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 10, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 10, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-10.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-10"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 10, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Luis Sojo" src="images/answer-2025-07-10.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Luis Sojo" src="images/answer-2025-07-10.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Luis Sojo
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won five World Series championships as a player.
         </li>
-        <li>
+<li>
          Drove in the series-winning run in the 2000 World Series.
         </li>
-        <li>
+<li>
          Managed the Venezuelan national team in three World Baseball Classics.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.2
           </td>
-          <td>
+<td>
            2571
           </td>
-          <td>
+<td>
            671
           </td>
-          <td>
+<td>
            36
           </td>
-          <td>
+<td>
            .261
           </td>
-          <td>
+<td>
            300
           </td>
-          <td>
+<td>
            261
           </td>
-          <td>
+<td>
            28
           </td>
-          <td>
+<td>
            .297
           </td>
-          <td>
+<td>
            .352
           </td>
-          <td>
+<td>
            .650
           </td>
-          <td>
+<td>
            71
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-10.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2003"];
             const warData = [0.1, 0.7, 1.8, -0.5, 1.1, 1.5, -0.7, 0.4, -0.2, 0.0, 0.7, -0.7, 0.0];
             const teamsByYear = ["TOR", "CAL", "CAL", "TOR", "SEA", "SEA", "2TM", "NYY", "NYY", "NYY", "2TM", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SEA", "CAL", "PIT", "NYY", "TOR"], "years": ["1992", "2000", "1993", "1990", "1994", "1991", "1999", "2001", "1997", "1995", "1998", "2003", "1996"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Luis Sojo", "hints": ["Won five World Series championships as a player.", "Drove in the series-winning run in the 2000 World Series.", "Managed the Venezuelan national team in three World Baseball Classics."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-10.html
+++ b/2025-07-10.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-10" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Luis Sojo.">
   <title>
    Luis Sojo Answer - July 10, 2025 | Name That Yankee
   </title>

--- a/2025-07-11.html
+++ b/2025-07-11.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-11" rel="canonical"/><meta content="Discover the career highlights and statistics for Rick Reuschel, the featured New York Yankee for the 2025-07-11 trivia puzzle." name="description"/>
+
+<title>
    Rick Reuschel Answer - July 11, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 11, 2025: Rick Reuschel. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 11, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 11, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-11.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 11, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 11, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-11.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-11"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 11, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Rick Reuschel" src="images/answer-2025-07-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Rick Reuschel" src="images/answer-2025-07-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Rick Reuschel "Big Daddy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Combined with brother Paul to pitch a shutout for the Chicago Cubs in 1975.
         </li>
-        <li>
+<li>
          Won two Gold Glove Awards after turning 36 years old.
         </li>
-        <li>
+<li>
          Finished third in Cy Young Award voting at age 40.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            69.5
           </td>
-          <td>
+<td>
            214
           </td>
-          <td>
+<td>
            191
           </td>
-          <td>
+<td>
            3.37
           </td>
-          <td>
+<td>
            557
           </td>
-          <td>
+<td>
            529
           </td>
-          <td>
+<td>
            5
           </td>
-          <td>
+<td>
            3548.1
           </td>
-          <td>
+<td>
            2015
           </td>
-          <td>
+<td>
            1.275
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [2.9, 5.8, 3.5, 3.3, 4.7, 9.5, 5.5, 5.7, 5.7, 3.2, 0.3, -0.2, 6.2, 1.1, 3.9, 3.7, 2.7, 0.8, -0.1];
             const teamsByYear = ["CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "2TM", "CHC", "CHC", "PIT", "PIT", "2TM", "SFG", "SFG", "SFG", "SFG"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHC", "SFG", "PIT"], "years": ["1990", "1977", "1979", "1972", "1987", "1980", "1981", "1975", "1988", "1973", "1983", "1974", "1976", "1986", "1985", "1978", "1991", "1989", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Rick Reuschel", "hints": ["Combined with brother Paul to pitch a shutout for the Chicago Cubs in 1975.", "Won two Gold Glove Awards after turning 36 years old.", "Finished third in Cy Young Award voting at age 40."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-11.html
+++ b/2025-07-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Rick Reuschel.">
   <title>
    Rick Reuschel Answer - July 11, 2025 | Name That Yankee
   </title>

--- a/2025-07-12.html
+++ b/2025-07-12.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-12" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-12" rel="canonical"/><meta content="Discover the career highlights and statistics for Jay Johnstone, the featured New York Yankee for the 2025-07-12 trivia puzzle." name="description"/>
+
+<title>
    Jay Johnstone Answer - July 12, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 12, 2025: Jay Johnstone. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 12, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-12.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 12, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-12.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 12, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 12, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-12.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-12"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 12, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jay Johnstone" src="images/answer-2025-07-12.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jay Johnstone" src="images/answer-2025-07-12.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jay Johnstone
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won World Series titles with the New York Yankees in 1978 and the Los Angeles Dodgers in 1981.
         </li>
-        <li>
+<li>
          Hit a pinch-hit, two-run home run in Game Four of the 1981 World Series.
         </li>
-        <li>
+<li>
          Hit a pinch-hit home run in the final at-bat of a 20-season career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            16.5
           </td>
-          <td>
+<td>
            4703
           </td>
-          <td>
+<td>
            1254
           </td>
-          <td>
+<td>
            102
           </td>
-          <td>
+<td>
            .267
           </td>
-          <td>
+<td>
            578
           </td>
-          <td>
+<td>
            531
           </td>
-          <td>
+<td>
            50
           </td>
-          <td>
+<td>
            .329
           </td>
-          <td>
+<td>
            .394
           </td>
-          <td>
+<td>
            .722
           </td>
-          <td>
+<td>
            103
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-12.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984"];
             const warData = [0.5, 0.5, 0.5, 2.9, 0.6, 1.6, -0.8, -0.2, 0.8, 2.6, 4.3, 1.9, -0.7, -0.2, 1.2, -0.1, 1.0, 0.4, 0.1];
             const teamsByYear = ["CAL", "CAL", "CAL", "CAL", "CAL", "CHW", "CHW", "OAK", "PHI", "PHI", "PHI", "PHI", "2TM", "2TM", "LAD", "LAD", "2TM", "CHC", "CHC"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["PHI", "LAD", "CAL", "CHW", "NYY", "SDP", "CHC", "OAK"], "years": ["1970", "1977", "1966", "1967", "1979", "1972", "1982", "1980", "1981", "1975", "1969", "1973", "1983", "1974", "1976", "1971", "1968", "1978", "1984"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jay Johnstone", "hints": ["Won World Series titles with the New York Yankees in 1978 and the Los Angeles Dodgers in 1981.", "Hit a pinch-hit, two-run home run in Game Four of the 1981 World Series.", "Hit a pinch-hit home run in the final at-bat of a 20-season career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-12.html
+++ b/2025-07-12.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-12" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jay Johnstone.">
   <title>
    Jay Johnstone Answer - July 12, 2025 | Name That Yankee
   </title>

--- a/2025-07-13.html
+++ b/2025-07-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-13" rel="canonical"/><meta content="Discover the career highlights and statistics for Joe Pepitone, the featured New York Yankee for the 2025-07-13 trivia puzzle." name="description"/>
+
+<title>
    Joe Pepitone Answer - July 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 13, 2025: Joe Pepitone. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Joe Pepitone" src="images/answer-2025-07-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Joe Pepitone" src="images/answer-2025-07-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Joe Pepitone "Pepi"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a three-time American League All-Star.
         </li>
-        <li>
+<li>
          Won three Gold Glove awards at first base.
         </li>
-        <li>
+<li>
          Hit home runs in the first two at-bats of a World Series career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            9.8
           </td>
-          <td>
+<td>
            5097
           </td>
-          <td>
+<td>
            1315
           </td>
-          <td>
+<td>
            219
           </td>
-          <td>
+<td>
            .258
           </td>
-          <td>
+<td>
            606
           </td>
-          <td>
+<td>
            721
           </td>
-          <td>
+<td>
            41
           </td>
-          <td>
+<td>
            .301
           </td>
-          <td>
+<td>
            .432
           </td>
-          <td>
+<td>
            .733
           </td>
-          <td>
+<td>
            105
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973"];
             const warData = [-0.2, 2.9, -0.7, 1.1, 2.7, 0.1, 0.9, 0.7, 1.3, 1.1, -0.1, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "CHC", "CHC", "2TM"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHC", "ATL", "HOU"], "years": ["1964", "1962", "1969", "1973", "1963", "1970", "1968", "1971", "1965", "1966", "1967", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Joe Pepitone", "hints": ["Was a three-time American League All-Star.", "Won three Gold Glove awards at first base.", "Hit home runs in the first two at-bats of a World Series career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-13.html
+++ b/2025-07-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Joe Pepitone.">
   <title>
    Joe Pepitone Answer - July 13, 2025 | Name That Yankee
   </title>

--- a/2025-07-18.html
+++ b/2025-07-18.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-18" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mark Wohlers.">
   <title>
    Mark Wohlers Answer - July 18, 2025 | Name That Yankee
   </title>

--- a/2025-07-18.html
+++ b/2025-07-18.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-18" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-18" rel="canonical"/><meta content="Discover the career highlights and statistics for Mark Wohlers, the featured New York Yankee for the 2025-07-18 trivia puzzle." name="description"/>
+
+<title>
    Mark Wohlers Answer - July 18, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 18, 2025: Mark Wohlers. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 18, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-18.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 18, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-18.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 18, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-18.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 18, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-18.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-18"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 18, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mark Wohlers" src="images/answer-2025-07-18.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mark Wohlers" src="images/answer-2025-07-18.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mark Wohlers
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was officially clocked throwing a 103 mph fastball in 1995.
         </li>
-        <li>
+<li>
          Recorded the final out of the 1995 World Series.
         </li>
-        <li>
+<li>
          Walked 33 batters in 20.1 innings pitched during the 1998 season.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            3.9
           </td>
-          <td>
+<td>
            39
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            3.97
           </td>
-          <td>
+<td>
            533
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            119
           </td>
-          <td>
+<td>
            553.1
           </td>
-          <td>
+<td>
            557
           </td>
-          <td>
+<td>
            1.377
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-18.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-18.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002"];
             const warData = [0.5, 0.6, -0.4, -1.0, 2.6, 1.8, 0.7, -1.3, -0.1, 0.2, 0.2, 0.2];
             const teamsByYear = ["ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "ATL", "CIN", "2TM", "CLE"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CIN", "ATL", "CLE"], "years": ["1992", "2000", "1993", "1994", "1991", "1999", "2001", "2002", "1997", "1995", "1998", "1996"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mark Wohlers", "hints": ["Was officially clocked throwing a 103 mph fastball in 1995.", "Recorded the final out of the 1995 World Series.", "Walked 33 batters in 20.1 innings pitched during the 1998 season."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-19.html
+++ b/2025-07-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul Zuvella.">
   <title>
    Paul Zuvella Answer - July 19, 2025 | Name That Yankee
   </title>

--- a/2025-07-19.html
+++ b/2025-07-19.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul Zuvella, the featured New York Yankee for the 2025-07-19 trivia puzzle." name="description"/>
+
+<title>
    Paul Zuvella Answer - July 19, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 19, 2025: Paul Zuvella. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 19, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 19, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-19.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 19, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 19, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-19.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-19"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 19, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul Zuvella" src="images/answer-2025-07-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul Zuvella" src="images/answer-2025-07-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul Zuvella
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the opposing shortstop in a rained-out 1986 game that saved Cal Ripken Jr.'s consecutive games streak.
         </li>
-        <li>
+<li>
          Hit two home runs in a nine-season MLB career spanning 209 games.
         </li>
-        <li>
+<li>
          Father of a minor league player drafted by the Montreal Expos in 2003.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -2.3
           </td>
-          <td>
+<td>
            491
           </td>
-          <td>
+<td>
            109
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            .222
           </td>
-          <td>
+<td>
            41
           </td>
-          <td>
+<td>
            20
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            .275
           </td>
-          <td>
+<td>
            .277
           </td>
-          <td>
+<td>
            .552
           </td>
-          <td>
+<td>
            53
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1991"];
             const warData = [0.0, -0.1, -0.1, -0.3, -0.8, -0.5, -0.7, 0.2, -0.1];
             const teamsByYear = ["ATL", "ATL", "ATL", "ATL", "NYY", "NYY", "CLE", "CLE", "KCR"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "ATL", "CLE", "KCR"], "years": ["1986", "1982", "1985", "1987", "1983", "1991", "1989", "1984", "1988"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul Zuvella", "hints": ["Was the opposing shortstop in a rained-out 1986 game that saved Cal Ripken Jr.'s consecutive games streak.", "Hit two home runs in a nine-season MLB career spanning 209 games.", "Father of a minor league player drafted by the Montreal Expos in 2003."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-20.html
+++ b/2025-07-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Clete Boyer.">
   <title>
    Clete Boyer Answer - July 20, 2025 | Name That Yankee
   </title>

--- a/2025-07-20.html
+++ b/2025-07-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-20" rel="canonical"/><meta content="Discover the career highlights and statistics for Clete Boyer, the featured New York Yankee for the 2025-07-20 trivia puzzle." name="description"/>
+
+<title>
    Clete Boyer Answer - July 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 20, 2025: Clete Boyer. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Clete Boyer" src="images/answer-2025-07-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Clete Boyer" src="images/answer-2025-07-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Clete Boyer
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Played against brother Ken in the 1964 World Series, with both brothers hitting a home run in Game 7.
         </li>
-        <li>
+<li>
          Appeared in five consecutive World Series with the New York Yankees from 1960 to 1964.
         </li>
-        <li>
+<li>
          Played four seasons in Japan for the Taiyo Whales from 1972 to 1975.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.8
           </td>
-          <td>
+<td>
            5780
           </td>
-          <td>
+<td>
            1396
           </td>
-          <td>
+<td>
            162
           </td>
-          <td>
+<td>
            .242
           </td>
-          <td>
+<td>
            645
           </td>
-          <td>
+<td>
            654
           </td>
-          <td>
+<td>
            41
           </td>
-          <td>
+<td>
            .299
           </td>
-          <td>
+<td>
            .372
           </td>
-          <td>
+<td>
            .670
           </td>
-          <td>
+<td>
            86
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1955", "1956", "1957", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971"];
             const warData = [-0.6, 0.1, -0.1, -0.5, 2.5, 3.8, 4.6, 2.5, -0.2, 2.9, 4.1, 3.1, 1.0, 2.8, 1.3, 0.6];
             const teamsByYear = ["KCA", "KCA", "KCA", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "ATL", "ATL", "ATL", "ATL", "ATL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "ATL", "KCA"], "years": ["1964", "1957", "1961", "1962", "1969", "1955", "1963", "1959", "1968", "1956", "1970", "1971", "1965", "1966", "1967", "1960"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Clete Boyer", "hints": ["Played against brother Ken in the 1964 World Series, with both brothers hitting a home run in Game 7.", "Appeared in five consecutive World Series with the New York Yankees from 1960 to 1964.", "Played four seasons in Japan for the Taiyo Whales from 1972 to 1975."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-21.html
+++ b/2025-07-21.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-21" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-21" rel="canonical"/><meta content="Discover the career highlights and statistics for Vernon Wells, the featured New York Yankee for the 2025-07-21 trivia puzzle." name="description"/>
+
+<title>
    Vernon Wells Answer - July 21, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 21, 2025: Vernon Wells. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 21, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-21.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 21, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-21.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 21, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-21.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 21, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-21.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-21"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 21, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Vernon Wells" src="images/answer-2025-07-21.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Vernon Wells" src="images/answer-2025-07-21.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Vernon Wells
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won three consecutive Gold Glove Awards from 2004 to 2006.
         </li>
-        <li>
+<li>
          Is the Toronto Blue Jays' all-time franchise leader in at-bats and hits.
         </li>
-        <li>
+<li>
          Led the American League in total bases, hits, and doubles in 2003.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            28.6
           </td>
-          <td>
+<td>
            6642
           </td>
-          <td>
+<td>
            1794
           </td>
-          <td>
+<td>
            270
           </td>
-          <td>
+<td>
            .270
           </td>
-          <td>
+<td>
            930
           </td>
-          <td>
+<td>
            958
           </td>
-          <td>
+<td>
            109
           </td>
-          <td>
+<td>
            .319
           </td>
-          <td>
+<td>
            .459
           </td>
-          <td>
+<td>
            .778
           </td>
-          <td>
+<td>
            104
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-21.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-21.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013"];
             const warData = [-0.4, -0.1, 0.7, 1.7, 4.5, 4.5, 3.2, 6.2, 1.4, 2.0, 0.9, 4.0, -0.5, 0.5, -0.1];
             const teamsByYear = ["TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "TOR", "LAA", "LAA", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "TOR", "LAA"], "years": ["2005", "2000", "2012", "2009", "2004", "2010", "2008", "2001", "2007", "2002", "1999", "2013", "2011", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Vernon Wells", "hints": ["Won three consecutive Gold Glove Awards from 2004 to 2006.", "Is the Toronto Blue Jays' all-time franchise leader in at-bats and hits.", "Led the American League in total bases, hits, and doubles in 2003."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-21.html
+++ b/2025-07-21.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-21" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Vernon Wells.">
   <title>
    Vernon Wells Answer - July 21, 2025 | Name That Yankee
   </title>

--- a/2025-07-22.html
+++ b/2025-07-22.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-22" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-22" rel="canonical"/><meta content="Discover the career highlights and statistics for Brandon Drury, the featured New York Yankee for the 2025-07-22 trivia puzzle." name="description"/>
+
+<title>
    Brandon Drury Answer - July 22, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 22, 2025: Brandon Drury. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 22, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-22.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 22, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-22.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 22, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-22.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 22, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-22.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,193 +42,193 @@
   "datePublished": "2025-07-22"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 22, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Brandon Drury" src="images/answer-2025-07-22.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Brandon Drury" src="images/answer-2025-07-22.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Brandon Drury
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</div>
+<ul>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.2
           </td>
-          <td>
+<td>
            2915
           </td>
-          <td>
+<td>
            713
           </td>
-          <td>
+<td>
            109
           </td>
-          <td>
+<td>
            .245
           </td>
-          <td>
+<td>
            337
           </td>
-          <td>
+<td>
            375
           </td>
-          <td>
+<td>
            5
           </td>
-          <td>
+<td>
            .296
           </td>
-          <td>
+<td>
            .421
           </td>
-          <td>
+<td>
            .717
           </td>
-          <td>
+<td>
            90
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-22.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-22.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024"];
             const warData = [-0.1, -0.1, 1.6, -0.4, -0.7, -0.9, 0.2, 2.7, 2.0, -2.0];
             const teamsByYear = ["ARI", "ARI", "ARI", "2TM", "TOR", "TOR", "NYM", "2TM", "LAA", "LAA"];
@@ -348,26 +349,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["ARI", "LAA", "NYM", "NYY", "CIN", "TOR", "SDP"], "years": ["2016", "2015", "2024", "2018", "2019", "2020", "2022", "2021", "2023", "2017"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Brandon Drury", "hints": []}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -378,11 +379,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-22.html
+++ b/2025-07-22.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-22" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Brandon Drury.">
   <title>
    Brandon Drury Answer - July 22, 2025 | Name That Yankee
   </title>

--- a/2025-07-23.html
+++ b/2025-07-23.html
@@ -1,24 +1,25 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Dale Murray, the featured New York Yankee for the 2025-07-23 trivia puzzle." name="description"/>
+
+<title>
    Dale Murray Answer - July 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 23, 2025: Dale Murray. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+
+<meta content="Name That Yankee - July 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -40,190 +41,190 @@
   "datePublished": "2025-07-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Dale Murray" src="images/answer-2025-07-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Dale Murray" src="images/answer-2025-07-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Dale Murray
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a National League All-Star in 1979.
         </li>
-        <li>
+<li>
          Won a World Series with the Cincinnati Reds in 1976.
         </li>
-        <li>
+<li>
          Led the National League in games pitched with 81 as a rookie in 1974.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.4
           </td>
-          <td>
+<td>
            53
           </td>
-          <td>
+<td>
            50
           </td>
-          <td>
+<td>
            3.85
           </td>
-          <td>
+<td>
            518
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            60
           </td>
-          <td>
+<td>
            902.1
           </td>
-          <td>
+<td>
            400
           </td>
-          <td>
+<td>
            1.446
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985"];
             const warData = [2.6, -0.3, 1.6, -0.9, -0.2, -0.6, -0.9, 0.6, 1.9, -0.5, -0.1, -0.2];
             const teamsByYear = ["MON", "MON", "MON", "CIN", "2TM", "2TM", "MON", "TOR", "TOR", "NYY", "NYY", "2TM"];
@@ -344,26 +345,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MON", "NYM", "TOR", "NYY", "TEX", "CIN"], "years": ["1984", "1974", "1978", "1981", "1982", "1980", "1983", "1985", "1976", "1979", "1977", "1975"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Dale Murray", "hints": ["Was a National League All-Star in 1979.", "Won a World Series with the Cincinnati Reds in 1976.", "Led the National League in games pitched with 81 as a rookie in 1974."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -374,11 +375,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-23.html
+++ b/2025-07-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Dale Murray.">
   <title>
    Dale Murray Answer - July 23, 2025 | Name That Yankee
   </title>

--- a/2025-07-26.html
+++ b/2025-07-26.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-26" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-26" rel="canonical"/><meta content="Discover the career highlights and statistics for Al Holland, the featured New York Yankee for the 2025-07-26 trivia puzzle." name="description"/>
+
+<title>
    Al Holland Answer - July 26, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 26, 2025: Al Holland. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 26, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-26.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 26, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-26.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 26, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-26.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 26, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-26.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-26"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 26, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Al Holland" src="images/answer-2025-07-26.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Al Holland" src="images/answer-2025-07-26.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Al Holland "Mr. T"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1983 NL Rolaids Relief Man and Sporting News Fireman of the Year awards.
         </li>
-        <li>
+<li>
          Was a 1983 National League All-Star and received votes for both the Cy Young and MVP awards.
         </li>
-        <li>
+<li>
          Led the National League in saves with 29 in 1984.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.9
           </td>
-          <td>
+<td>
            34
           </td>
-          <td>
+<td>
            30
           </td>
-          <td>
+<td>
            2.98
           </td>
-          <td>
+<td>
            384
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            78
           </td>
-          <td>
+<td>
            646.0
           </td>
-          <td>
+<td>
            513
           </td>
-          <td>
+<td>
            1.207
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-26.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-26.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1977", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987"];
             const warData = [-0.1, 0.3, 2.7, 2.2, 1.4, 3.3, 1.4, 1.8, -0.6, -0.3];
             const teamsByYear = ["PIT", "SFG", "SFG", "SFG", "SFG", "PHI", "PHI", "3TM", "NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SFG", "NYY", "2TM", "PIT", "PHI", "CAL"], "years": ["1982", "1986", "1981", "1977", "1980", "1984", "1983", "1987", "1979", "1985"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Al Holland", "hints": ["Won the 1983 NL Rolaids Relief Man and Sporting News Fireman of the Year awards.", "Was a 1983 National League All-Star and received votes for both the Cy Young and MVP awards.", "Led the National League in saves with 29 in 1984."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-26.html
+++ b/2025-07-26.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-26" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Al Holland.">
   <title>
    Al Holland Answer - July 26, 2025 | Name That Yankee
   </title>

--- a/2025-07-27.html
+++ b/2025-07-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ronald Torreyes.">
   <title>
    Ronald Torreyes Answer - July 27, 2025 | Name That Yankee
   </title>

--- a/2025-07-27.html
+++ b/2025-07-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Ronald Torreyes, the featured New York Yankee for the 2025-07-27 trivia puzzle." name="description"/>
+
+<title>
    Ronald Torreyes Answer - July 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 27, 2025: Ronald Torreyes. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ronald Torreyes" src="images/answer-2025-07-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ronald Torreyes" src="images/answer-2025-07-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ronald Torreyes "Toe"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was claimed off waivers by the Minnesota Twins twice during the 2018-2019 offseason.
         </li>
-        <li>
+<li>
          Played in a career-high 108 games for the 2017 New York Yankees, hitting .292.
         </li>
-        <li>
+<li>
          Pitched one inning as a position player for the Philadelphia Phillies in 2021.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.2
           </td>
-          <td>
+<td>
            917
           </td>
-          <td>
+<td>
            243
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            .265
           </td>
-          <td>
+<td>
            99
           </td>
-          <td>
+<td>
            98
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            .299
           </td>
-          <td>
+<td>
            .361
           </td>
-          <td>
+<td>
            .660
           </td>
-          <td>
+<td>
            76
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2015", "2016", "2017", "2018", "2019", "2020", "2021"];
             const warData = [0.1, 0.3, 0.8, 0.2, -0.2, -0.1, 0.2];
             const teamsByYear = ["LAD", "NYY", "NYY", "NYY", "MIN", "PHI", "PHI"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "PHI", "LAD", "MIN"], "years": ["2016", "2015", "2018", "2019", "2020", "2021", "2017"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ronald Torreyes", "hints": ["Was claimed off waivers by the Minnesota Twins twice during the 2018-2019 offseason.", "Played in a career-high 108 games for the 2017 New York Yankees, hitting .292.", "Pitched one inning as a position player for the Philadelphia Phillies in 2021."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-28.html
+++ b/2025-07-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Roy White, the featured New York Yankee for the 2025-07-28 trivia puzzle." name="description"/>
+
+<title>
    Roy White Answer - July 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 28, 2025: Roy White. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Roy White" src="images/answer-2025-07-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Roy White" src="images/answer-2025-07-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Roy White
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Holds the New York Yankees franchise record for career sacrifice flies with 111.
         </li>
-        <li>
+<li>
          Set the American League record by hitting home runs from both sides of the plate in the same game 14 times.
         </li>
-        <li>
+<li>
          Won a Japan Series championship in 1981 with the Yomiuri Giants.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            46.8
           </td>
-          <td>
+<td>
            6650
           </td>
-          <td>
+<td>
            1803
           </td>
-          <td>
+<td>
            160
           </td>
-          <td>
+<td>
            .271
           </td>
-          <td>
+<td>
            964
           </td>
-          <td>
+<td>
            758
           </td>
-          <td>
+<td>
            233
           </td>
-          <td>
+<td>
            .360
           </td>
-          <td>
+<td>
            .404
           </td>
-          <td>
+<td>
            .764
           </td>
-          <td>
+<td>
            121
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979"];
             const warData = [0.3, 0.2, -0.5, 4.4, 4.2, 6.8, 6.7, 5.3, 3.5, 3.2, 4.0, 5.5, 3.6, 0.8, -1.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1975", "1976", "1969", "1973", "1970", "1971", "1968", "1978", "1977", "1965", "1966", "1974", "1967", "1979", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Roy White", "hints": ["Holds the New York Yankees franchise record for career sacrifice flies with 111.", "Set the American League record by hitting home runs from both sides of the plate in the same game 14 times.", "Won a Japan Series championship in 1981 with the Yomiuri Giants."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-28.html
+++ b/2025-07-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Roy White.">
   <title>
    Roy White Answer - July 28, 2025 | Name That Yankee
   </title>

--- a/2025-07-29.html
+++ b/2025-07-29.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-29" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Randy Choate.">
   <title>
    Randy Choate Answer - July 29, 2025 | Name That Yankee
   </title>

--- a/2025-07-29.html
+++ b/2025-07-29.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-29" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-29" rel="canonical"/><meta content="Discover the career highlights and statistics for Randy Choate, the featured New York Yankee for the 2025-07-29 trivia puzzle." name="description"/>
+
+<title>
    Randy Choate Answer - July 29, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 29, 2025: Randy Choate. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 29, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-29.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 29, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-29.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 29, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-29.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 29, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-29.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-29"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 29, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Randy Choate" src="images/answer-2025-07-29.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Randy Choate" src="images/answer-2025-07-29.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Randy Choate
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Finished a 15-year career with more games pitched (656) than innings pitched (387.1).
         </li>
-        <li>
+<li>
          Was the first pitcher in MLB history to make at least 70 appearances while pitching fewer than 30 innings in a single season.
         </li>
-        <li>
+<li>
          Won a World Series with the New York Yankees in 2000.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.5
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            3.90
           </td>
-          <td>
+<td>
            672
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            408.0
           </td>
-          <td>
+<td>
            348
           </td>
-          <td>
+<td>
            1.287
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-29.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-29.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2009", "2010", "2011", "2012", "2013", "2014", "2015"];
             const warData = [0.1, 0.8, -0.2, 0.0, 0.5, -0.4, 0.1, 0.0, 0.7, -0.1, 1.0, 0.6, 1.2, -0.1, 0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "ARI", "ARI", "ARI", "ARI", "TBR", "TBR", "FLA", "2TM", "STL", "STL", "STL"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "FLA", "ARI", "STL", "NYY", "MIA", "TBR"], "years": ["2005", "2000", "2012", "2009", "2015", "2010", "2001", "2007", "2002", "2004", "2013", "2011", "2014", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Randy Choate", "hints": ["Finished a 15-year career with more games pitched (656) than innings pitched (387.1).", "Was the first pitcher in MLB history to make at least 70 appearances while pitching fewer than 30 innings in a single season.", "Won a World Series with the New York Yankees in 2000."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-30.html
+++ b/2025-07-30.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-30" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Rey S\u00e1nchez.">
   <title>
    Rey Sánchez Answer - July 30, 2025 | Name That Yankee
   </title>

--- a/2025-07-30.html
+++ b/2025-07-30.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-30" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-30" rel="canonical"/><meta content="Discover the career highlights and statistics for Rey Sánchez, the featured New York Yankee for the 2025-07-30 trivia puzzle." name="description"/>
+
+<title>
    Rey Sánchez Answer - July 30, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 30, 2025: Rey Sánchez. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 30, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-30.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 30, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-30.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 30, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 30, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-30.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-07-30"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 30, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Rey Sánchez" src="images/answer-2025-07-30.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Rey Sánchez" src="images/answer-2025-07-30.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Rey Sánchez
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a World Series with the 1999 New York Yankees and the 2004 Boston Red Sox.
         </li>
-        <li>
+<li>
          Cousin of former MLB All-Star catcher Benito Santiago.
         </li>
-        <li>
+<li>
          Hit 13 home runs over a 15-year, 1,446-game career.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            20.6
           </td>
-          <td>
+<td>
            4850
           </td>
-          <td>
+<td>
            1317
           </td>
-          <td>
+<td>
            15
           </td>
-          <td>
+<td>
            .272
           </td>
-          <td>
+<td>
            549
           </td>
-          <td>
+<td>
            389
           </td>
-          <td>
+<td>
            55
           </td>
-          <td>
+<td>
            .308
           </td>
-          <td>
+<td>
            .334
           </td>
-          <td>
+<td>
            .642
           </td>
-          <td>
+<td>
            69
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-30.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005"];
             const warData = [0.2, 1.5, 2.3, 1.3, 0.8, 0.4, 0.2, 1.9, 3.6, 2.3, 3.4, 1.5, 0.1, 1.5, -0.4];
             const teamsByYear = ["CHC", "CHC", "CHC", "CHC", "CHC", "CHC", "2TM", "SFG", "KCR", "KCR", "2TM", "BOS", "2TM", "TBD", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SEA", "TBD", "SFG", "BOS", "NYM", "NYY", "ATL", "CHC", "KCR"], "years": ["2005", "1992", "2000", "1993", "1994", "2004", "1991", "1999", "2001", "2002", "1997", "1995", "1998", "2003", "1996"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Rey S\u00e1nchez", "hints": ["Won a World Series with the 1999 New York Yankees and the 2004 Boston Red Sox.", "Cousin of former MLB All-Star catcher Benito Santiago.", "Hit 13 home runs over a 15-year, 1,446-game career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-31.html
+++ b/2025-07-31.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-07-31" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-07-31" rel="canonical"/><meta content="Discover the career highlights and statistics for Sam Militello, the featured New York Yankee for the 2025-07-31 trivia puzzle." name="description"/>
+
+<title>
    Sam Militello Answer - July 31, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on July 31, 2025: Sam Militello. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - July 31, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-07-31.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - July 31, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-07-31.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - July 31, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-07-31.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - July 31, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-07-31.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-07-31"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for July 31, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Sam Militello" src="images/answer-2025-07-31.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Sam Militello" src="images/answer-2025-07-31.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Sam Militello
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched a complete game shutout in a Major League debut.
         </li>
-        <li>
+<li>
          Was named the 1991 Baseball America Minor League Player of the Year.
         </li>
-        <li>
+<li>
          Was the 1990 NCAA Division II Player of the Year.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.2
           </td>
-          <td>
+<td>
            4
           </td>
-          <td>
+<td>
            4
           </td>
-          <td>
+<td>
            3.89
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            69.1
           </td>
-          <td>
+<td>
            47
           </td>
-          <td>
+<td>
            1.327
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-07-31.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-07-31.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1992", "1993"];
             const warData = [1.4, -0.2];
             const teamsByYear = ["NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1993", "1992"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Sam Militello", "hints": ["Pitched a complete game shutout in a Major League debut.", "Was named the 1991 Baseball America Minor League Player of the Year.", "Was the 1990 NCAA Division II Player of the Year."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-07-31.html
+++ b/2025-07-31.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-07-31" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Sam Militello.">
   <title>
    Sam Militello Answer - July 31, 2025 | Name That Yankee
   </title>

--- a/2025-08-01.html
+++ b/2025-08-01.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-01" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mike Lowell.">
   <title>
    Mike Lowell Answer - August 01, 2025 | Name That Yankee
   </title>

--- a/2025-08-01.html
+++ b/2025-08-01.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-01" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-01" rel="canonical"/><meta content="Discover the career highlights and statistics for Mike Lowell, the featured New York Yankee for the 2025-08-01 trivia puzzle." name="description"/>
+
+<title>
    Mike Lowell Answer - August 01, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 01, 2025: Mike Lowell. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 01, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-01.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 01, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-01.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 01, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-01.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 01, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-01.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-08-01"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 01, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mike Lowell" src="images/answer-2025-08-01.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mike Lowell" src="images/answer-2025-08-01.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mike Lowell
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the 2007 World Series MVP.
         </li>
-        <li>
+<li>
          Won the 1999 Tony Conigliaro Award after returning from a cancer diagnosis.
         </li>
-        <li>
+<li>
          Won a World Series championship with both the Florida Marlins and the Boston Red Sox.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            24.8
           </td>
-          <td>
+<td>
            5813
           </td>
-          <td>
+<td>
            1619
           </td>
-          <td>
+<td>
            223
           </td>
-          <td>
+<td>
            .279
           </td>
-          <td>
+<td>
            771
           </td>
-          <td>
+<td>
            952
           </td>
-          <td>
+<td>
            30
           </td>
-          <td>
+<td>
            .342
           </td>
-          <td>
+<td>
            .464
           </td>
-          <td>
+<td>
            .805
           </td>
-          <td>
+<td>
            108
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-01.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-01.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010"];
             const warData = [0.1, 0.1, 2.2, 2.8, 3.0, 2.8, 4.3, -0.9, 3.3, 5.0, 2.4, 0.0, -0.1];
             const teamsByYear = ["NYY", "FLA", "FLA", "FLA", "FLA", "FLA", "FLA", "FLA", "BOS", "BOS", "BOS", "BOS", "BOS"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "BOS", "FLA"], "years": ["2005", "2000", "2009", "2004", "2010", "2008", "2001", "2007", "2002", "1999", "1998", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mike Lowell", "hints": ["Was the 2007 World Series MVP.", "Won the 1999 Tony Conigliaro Award after returning from a cancer diagnosis.", "Won a World Series championship with both the Florida Marlins and the Boston Red Sox."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-02.html
+++ b/2025-08-02.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-02" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Randy Choate.">
   <title>
    Randy Choate Answer - August 02, 2025 | Name That Yankee
   </title>

--- a/2025-08-02.html
+++ b/2025-08-02.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-02" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-02" rel="canonical"/><meta content="Discover the career highlights and statistics for Randy Choate, the featured New York Yankee for the 2025-08-02 trivia puzzle." name="description"/>
+
+<title>
    Randy Choate Answer - August 02, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 02, 2025: Randy Choate. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 02, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-02.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 02, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-02.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 02, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-02.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 02, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-02.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-08-02"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 02, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Randy Choate" src="images/answer-2025-08-02.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Randy Choate" src="images/answer-2025-08-02.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Randy Choate
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a World Series in consecutive seasons with two different teams (2000 Yankees, 2001 Diamondbacks).
         </li>
-        <li>
+<li>
          Led the American League with 85 games pitched in 2010 while recording only 31.2 innings.
         </li>
-        <li>
+<li>
          Appeared in 831 career games, ranking in the top 70 all-time for pitchers.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.5
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            3.90
           </td>
-          <td>
+<td>
            672
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            408.0
           </td>
-          <td>
+<td>
            348
           </td>
-          <td>
+<td>
            1.287
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-02.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-02.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2009", "2010", "2011", "2012", "2013", "2014", "2015"];
             const warData = [0.1, 0.8, -0.2, 0.0, 0.5, -0.4, 0.1, 0.0, 0.7, -0.1, 1.0, 0.6, 1.2, -0.1, 0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "ARI", "ARI", "ARI", "ARI", "TBR", "TBR", "FLA", "2TM", "STL", "STL", "STL"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["LAD", "FLA", "ARI", "STL", "NYY", "MIA", "TBR"], "years": ["2005", "2000", "2012", "2009", "2015", "2010", "2001", "2007", "2002", "2004", "2013", "2011", "2014", "2003", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Randy Choate", "hints": ["Won a World Series in consecutive seasons with two different teams (2000 Yankees, 2001 Diamondbacks).", "Led the American League with 85 games pitched in 2010 while recording only 31.2 innings.", "Appeared in 831 career games, ranking in the top 70 all-time for pitchers."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-03.html
+++ b/2025-08-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jorge Posada.">
   <title>
    Jorge Posada Answer - August 03, 2025 | Name That Yankee
   </title>

--- a/2025-08-03.html
+++ b/2025-08-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-03" rel="canonical"/><meta content="Discover the career highlights and statistics for Jorge Posada, the featured New York Yankee for the 2025-08-03 trivia puzzle." name="description"/>
+
+<title>
    Jorge Posada Answer - August 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 03, 2025: Jorge Posada. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-08-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jorge Posada" src="images/answer-2025-08-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jorge Posada" src="images/answer-2025-08-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jorge Posada "Jorgie"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Is the all-time leader in home runs (275) and RBIs (1,065) among switch-hitting catchers.
         </li>
-        <li>
+<li>
          Caught a perfect game in 1998 and a no-hitter in 1999.
         </li>
-        <li>
+<li>
          Uncle, Leo Posada, played for the Kansas City Athletics from 1960-1962.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            42.7
           </td>
-          <td>
+<td>
            6092
           </td>
-          <td>
+<td>
            1664
           </td>
-          <td>
+<td>
            275
           </td>
-          <td>
+<td>
            .273
           </td>
-          <td>
+<td>
            900
           </td>
-          <td>
+<td>
            1065
           </td>
-          <td>
+<td>
            20
           </td>
-          <td>
+<td>
            .374
           </td>
-          <td>
+<td>
            .474
           </td>
-          <td>
+<td>
            .848
           </td>
-          <td>
+<td>
            121
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011"];
             const warData = [0.0, -0.3, 0.6, 2.9, 1.1, 5.5, 3.0, 4.0, 5.9, 3.5, 4.4, 4.0, 5.4, 0.2, 1.6, 1.3, -0.4];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["2005", "2000", "2009", "1997", "2004", "2010", "2008", "2001", "2007", "2002", "1999", "1995", "1998", "2011", "2003", "1996", "2006"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jorge Posada", "hints": ["Is the all-time leader in home runs (275) and RBIs (1,065) among switch-hitting catchers.", "Caught a perfect game in 1998 and a no-hitter in 1999.", "Uncle, Leo Posada, played for the Kansas City Athletics from 1960-1962."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-04.html
+++ b/2025-08-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Billy Sample.">
   <title>
    Billy Sample Answer - August 04, 2025 | Name That Yankee
   </title>

--- a/2025-08-04.html
+++ b/2025-08-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Billy Sample, the featured New York Yankee for the 2025-08-04 trivia puzzle." name="description"/>
+
+<title>
    Billy Sample Answer - August 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 04, 2025: Billy Sample. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,193 +42,193 @@
   "datePublished": "2025-08-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Billy Sample" src="images/answer-2025-08-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Billy Sample" src="images/answer-2025-08-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Billy Sample
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</div>
+<ul>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            10.5
           </td>
-          <td>
+<td>
            2516
           </td>
-          <td>
+<td>
            684
           </td>
-          <td>
+<td>
            46
           </td>
-          <td>
+<td>
            .272
           </td>
-          <td>
+<td>
            371
           </td>
-          <td>
+<td>
            230
           </td>
-          <td>
+<td>
            98
           </td>
-          <td>
+<td>
            .329
           </td>
-          <td>
+<td>
            .384
           </td>
-          <td>
+<td>
            .713
           </td>
-          <td>
+<td>
            98
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986"];
             const warData = [0.1, 2.7, 0.2, 1.9, 1.6, 3.8, -0.9, 0.3, 0.6];
             const teamsByYear = ["TEX", "TEX", "TEX", "TEX", "TEX", "TEX", "TEX", "NYY", "ATL"];
@@ -348,18 +349,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "ATL", "TEX"], "years": ["1985", "1979", "1984", "1983", "1982", "1981", "1986", "1980", "1978"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Billy Sample", "hints": []}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -387,15 +388,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -406,11 +407,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-05.html
+++ b/2025-08-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Wayne Tolleson.">
   <title>
    Wayne Tolleson Answer - August 05, 2025 | Name That Yankee
   </title>

--- a/2025-08-05.html
+++ b/2025-08-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Wayne Tolleson, the featured New York Yankee for the 2025-08-05 trivia puzzle." name="description"/>
+
+<title>
    Wayne Tolleson Answer - August 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 05, 2025: Wayne Tolleson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Wayne Tolleson" src="images/answer-2025-08-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Wayne Tolleson" src="images/answer-2025-08-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Wayne Tolleson
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Stole 56 bases for the Chicago White Sox in 1985.
         </li>
-        <li>
+<li>
          Led the American League in sacrifice hits with 25 in 1987.
         </li>
-        <li>
+<li>
          Father of former major league infielder Steve Tolleson.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Wayne Tolleson?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Wayne Tolleson was a versatile utility infielder, valued for his speed and defensive flexibility across shortstop, second base, and third base. He played for the Texas Rangers, Chicago White Sox, and New York Yankees over a 10-year career. His best all-around season came in 1985 with Chicago, when he hit .274 and stole 56 bases.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Wayne Tolleson was a versatile utility infielder, valued for his speed and defensive flexibility across shortstop, second base, and third base. He played for the Texas Rangers, Chicago White Sox, and New York Yankees over a 10-year career. His best all-around season came in 1985 with Chicago, when he hit .274 and stole 56 bases.">
            What was Wayne Tolleson's primary role during his major league career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="While the Yankees did not make the postseason during his tenure from 1986 to 1990, Tolleson was a steady contributor. In 1987, he led the entire American League with 25 sacrifice hits, showcasing his skill at fundamental, team-oriented offense. He appeared in over 100 games for New York in both the 1987 and 1988 seasons.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="While the Yankees did not make the postseason during his tenure from 1986 to 1990, Tolleson was a steady contributor. In 1987, he led the entire American League with 25 sacrifice hits, showcasing his skill at fundamental, team-oriented offense. He appeared in over 100 games for New York in both the 1987 and 1988 seasons.">
            Did Wayne Tolleson have any notable moments or statistical achievements during his time with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring from baseball, Tolleson returned to his home state of South Carolina and became a successful high school baseball coach. He coached at his alma mater, Spartanburg High School, for many years. He also later worked as an area scout for the Kansas City Royals.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring from baseball, Tolleson returned to his home state of South Carolina and became a successful high school baseball coach. He coached at his alma mater, Spartanburg High School, for many years. He also later worked as an area scout for the Kansas City Royals.">
            What did Wayne Tolleson do after his playing career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.2
           </td>
-          <td>
+<td>
            331
           </td>
-          <td>
+<td>
            81
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            .245
           </td>
-          <td>
+<td>
            39
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            .299
           </td>
-          <td>
+<td>
            .372
           </td>
-          <td>
+<td>
            .670
           </td>
-          <td>
+<td>
            86
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2010", "2012", "2014", "2015"];
             const warData = [0.2, -0.3, 0.8, 0.5];
             const teamsByYear = ["OAK", "BAL", "TOR", "TOR"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TOR", "BAL", "OAK"], "years": ["2015", "2012", "2014", "2010"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Wayne Tolleson", "hints": ["Stole 56 bases for the Chicago White Sox in 1985.", "Led the American League in sacrifice hits with 25 in 1987.", "Father of former major league infielder Steve Tolleson."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-06.html
+++ b/2025-08-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Mark Leiter, the featured New York Yankee for the 2025-08-06 trivia puzzle." name="description"/>
+
+<title>
    Mark Leiter Answer - August 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 06, 2025: Mark Leiter. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-08-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mark Leiter" src="images/answer-2025-08-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mark Leiter" src="images/answer-2025-08-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mark Leiter
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Brother Al Leiter and son Mark Leiter Jr. also pitched in Major League Baseball.
         </li>
-        <li>
+<li>
          Pitched a complete game one-hitter for the Detroit Tigers in 1991.
         </li>
-        <li>
+<li>
          Received the 1994 Willie Mac Award as the most inspirational player for the San Francisco Giants.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            3.1
           </td>
-          <td>
+<td>
            65
           </td>
-          <td>
+<td>
            73
           </td>
-          <td>
+<td>
            4.57
           </td>
-          <td>
+<td>
            335
           </td>
-          <td>
+<td>
            149
           </td>
-          <td>
+<td>
            26
           </td>
-          <td>
+<td>
            1184.1
           </td>
-          <td>
+<td>
            892
           </td>
-          <td>
+<td>
            1.375
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2001"];
             const warData = [-0.5, 1.2, 0.4, 0.9, 0.8, 1.5, -0.3, -1.9, 1.3, 0.0, 0.5];
             const teamsByYear = ["NYY", "DET", "DET", "DET", "CAL", "SFG", "2TM", "PHI", "PHI", "SEA", "MIL"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SFG", "DET", "MON", "MIL", "CAL", "NYY", "SEA", "PHI"], "years": ["2001", "1993", "1997", "1994", "1992", "1998", "1995", "1996", "1999", "1990", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mark Leiter", "hints": ["Brother Al Leiter and son Mark Leiter Jr. also pitched in Major League Baseball.", "Pitched a complete game one-hitter for the Detroit Tigers in 1991.", "Received the 1994 Willie Mac Award as the most inspirational player for the San Francisco Giants."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-06.html
+++ b/2025-08-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mark Leiter.">
   <title>
    Mark Leiter Answer - August 06, 2025 | Name That Yankee
   </title>

--- a/2025-08-09.html
+++ b/2025-08-09.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-09" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-09" rel="canonical"/><meta content="Discover the career highlights and statistics for Bob Watson, the featured New York Yankee for the 2025-08-09 trivia puzzle." name="description"/>
+
+<title>
    Bob Watson Answer - August 09, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 09, 2025: Bob Watson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 09, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-09.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 09, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-09.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 09, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-09.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 09, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-09.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,202 +42,202 @@
   "datePublished": "2025-08-09"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 09, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bob Watson" src="images/answer-2025-08-09.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bob Watson" src="images/answer-2025-08-09.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bob Watson "The Bull"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Scored Major League Baseball's one-millionth run on May 4, 1975.
         </li>
-        <li>
+<li>
          Was the first player in history to hit for the cycle in both the National and American Leagues.
         </li>
-        <li>
+<li>
          Became the first African American general manager to win a World Series in 1996.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            28.3
           </td>
-          <td>
+<td>
            6185
           </td>
-          <td>
+<td>
            1826
           </td>
-          <td>
+<td>
            184
           </td>
-          <td>
+<td>
            .295
           </td>
-          <td>
+<td>
            802
           </td>
-          <td>
+<td>
            989
           </td>
-          <td>
+<td>
            27
           </td>
-          <td>
+<td>
            .364
           </td>
-          <td>
+<td>
            .447
           </td>
-          <td>
+<td>
            .811
           </td>
-          <td>
+<td>
            129
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-09.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-09.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984"];
             const warData = [0.0, 0.0, -0.4, 0.4, 0.1, 1.0, 2.9, 4.7, 0.7, 3.3, 3.0, 4.8, 3.0, 2.9, 2.4, -0.1, 0.0, 0.3, -0.3];
             const teamsByYear = ["HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "2TM", "NYY", "NYY", "2TM", "ATL", "ATL"];
@@ -357,26 +358,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["HOU", "BOS", "NYY", "ATL"], "years": ["1981", "1976", "1984", "1980", "1968", "1969", "1972", "1983", "1970", "1967", "1977", "1975", "1973", "1971", "1974", "1979", "1966", "1982", "1978"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bob Watson", "hints": ["Scored Major League Baseball's one-millionth run on May 4, 1975.", "Was the first player in history to hit for the cycle in both the National and American Leagues.", "Became the first African American general manager to win a World Series in 1996."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -387,11 +388,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-09.html
+++ b/2025-08-09.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-09" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bob Watson.">
   <title>
    Bob Watson Answer - August 09, 2025 | Name That Yankee
   </title>

--- a/2025-08-10.html
+++ b/2025-08-10.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-10" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Andy Pettitte.">
   <title>
    Andy Pettitte Answer - August 10, 2025 | Name That Yankee
   </title>

--- a/2025-08-10.html
+++ b/2025-08-10.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-10" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Andy Pettitte, the featured New York Yankee for the 2025-08-10 trivia puzzle." name="description"/>
+
+<title>
    Andy Pettitte Answer - August 10, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 10, 2025: Andy Pettitte. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 10, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-10.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 10, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-10.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 10, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 10, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-10.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-08-10"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 10, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Andy Pettitte" src="images/answer-2025-08-10.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Andy Pettitte" src="images/answer-2025-08-10.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Andy Pettitte "Petey"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Holds the all-time MLB record for postseason wins with 19.
         </li>
-        <li>
+<li>
          Never finished a season with a losing record in an 18-year career.
         </li>
-        <li>
+<li>
          Is the only pitcher drafted by the New York Yankees to win 200 games for the franchise.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            60.2
           </td>
-          <td>
+<td>
            256
           </td>
-          <td>
+<td>
            153
           </td>
-          <td>
+<td>
            3.85
           </td>
-          <td>
+<td>
            531
           </td>
-          <td>
+<td>
            521
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            3316.0
           </td>
-          <td>
+<td>
            2448
           </td>
-          <td>
+<td>
            1.351
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-10.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2012", "2013"];
             const warData = [2.9, 5.6, 8.4, 2.4, 2.4, 3.6, 3.5, 3.2, 3.1, 1.1, 6.8, 1.5, 3.8, 2.2, 3.4, 2.6, 2.1, 2.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "HOU", "HOU", "HOU", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["HOU", "NYY"], "years": ["2009", "2013", "2004", "2010", "2007", "2001", "2002", "1997", "2005", "2008", "1995", "2000", "1996", "2003", "1999", "2006", "2012", "1998"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Andy Pettitte", "hints": ["Holds the all-time MLB record for postseason wins with 19.", "Never finished a season with a losing record in an 18-year career.", "Is the only pitcher drafted by the New York Yankees to win 200 games for the franchise."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-11.html
+++ b/2025-08-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Phil Hughes.">
   <title>
    Phil Hughes Answer - August 11, 2025 | Name That Yankee
   </title>

--- a/2025-08-11.html
+++ b/2025-08-11.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-11" rel="canonical"/><meta content="Discover the career highlights and statistics for Phil Hughes, the featured New York Yankee for the 2025-08-11 trivia puzzle." name="description"/>
+
+<title>
    Phil Hughes Answer - August 11, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 11, 2025: Phil Hughes. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 11, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 11, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-11.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 11, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 11, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-11.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,181 +42,181 @@
   "datePublished": "2025-08-11"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 11, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Phil Hughes" src="images/answer-2025-08-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Phil Hughes" src="images/answer-2025-08-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Phil Hughes
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</div>
+<ul>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            11.0
           </td>
-          <td>
+<td>
            88
           </td>
-          <td>
+<td>
            79
           </td>
-          <td>
+<td>
            4.52
           </td>
-          <td>
+<td>
            290
           </td>
-          <td>
+<td>
            211
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            1291.0
           </td>
-          <td>
+<td>
            1040
           </td>
-          <td>
+<td>
            1.314
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018"];
             const warData = [0.9, -0.3, 2.6, 2.1, -0.4, 1.7, -0.9, 4.6, 1.8, -0.1, -0.5, -0.4];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "MIN", "MIN", "MIN", "MIN", "2TM"];
@@ -336,18 +337,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MIN", "NYY", "SDP"], "years": ["2009", "2013", "2011", "2010", "2016", "2014", "2007", "2015", "2018", "2012", "2008", "2017"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Phil Hughes", "hints": []}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -375,15 +376,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -394,11 +395,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-12.html
+++ b/2025-08-12.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-12" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Kevin Maas.">
   <title>
    Kevin Maas Answer - August 12, 2025 | Name That Yankee
   </title>

--- a/2025-08-12.html
+++ b/2025-08-12.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-12" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-12" rel="canonical"/><meta content="Discover the career highlights and statistics for Kevin Maas, the featured New York Yankee for the 2025-08-12 trivia puzzle." name="description"/>
+
+<title>
    Kevin Maas Answer - August 12, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 12, 2025: Kevin Maas. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 12, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-12.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 12, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-12.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 12, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 12, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-12.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-12"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 12, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Kevin Maas" src="images/answer-2025-08-12.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Kevin Maas" src="images/answer-2025-08-12.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Kevin Maas
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Set an MLB record as the fastest player to reach 15 career home runs, doing so in 133 at-bats.
         </li>
-        <li>
+<li>
          Finished second in the 1990 American League Rookie of the Year voting behind Sandy Alomar Jr.
         </li>
-        <li>
+<li>
          Played five professional seasons in Japan for the Hanshin Tigers and Chiba Lotte Marines.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Kevin Maas?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After hitting 21 home runs in 79 games in 1990, he hit 23 home runs in a full 1991 season, but his batting average dropped significantly. Pitchers adjusted to his pull-heavy, all-or-nothing approach, leading to high strikeout totals and declining production. He played parts of three more MLB seasons before his career in the majors concluded in 1995.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After hitting 21 home runs in 79 games in 1990, he hit 23 home runs in a full 1991 season, but his batting average dropped significantly. Pitchers adjusted to his pull-heavy, all-or-nothing approach, leading to high strikeout totals and declining production. He played parts of three more MLB seasons before his career in the majors concluded in 1995.">
            What was the story of Kevin Maas's career after his incredible rookie season?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="No, he never appeared in a postseason game. His primary tenure with the Yankees from 1990 to 1993 was a rebuilding period for the franchise, preceding the dynasty that began in the mid-1990s. The team did not qualify for the playoffs during any of his seasons in New York.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="No, he never appeared in a postseason game. His primary tenure with the Yankees from 1990 to 1993 was a rebuilding period for the franchise, preceding the dynasty that began in the mid-1990s. The team did not qualify for the playoffs during any of his seasons in New York.">
            Did Maas ever get to play in the postseason with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring from baseball, he pursued a career in finance. He became a certified financial planner and a financial advisor for a major firm. In this role, he has often worked with other professional athletes to help manage their finances.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring from baseball, he pursued a career in finance. He became a certified financial planner and a financial advisor for a major firm. In this role, he has often worked with other professional athletes to help manage their finances.">
            What did he do after his playing career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.5
           </td>
-          <td>
+<td>
            1248
           </td>
-          <td>
+<td>
            287
           </td>
-          <td>
+<td>
            65
           </td>
-          <td>
+<td>
            .230
           </td>
-          <td>
+<td>
            171
           </td>
-          <td>
+<td>
            169
           </td>
-          <td>
+<td>
            10
           </td>
-          <td>
+<td>
            .329
           </td>
-          <td>
+<td>
            .422
           </td>
-          <td>
+<td>
            .752
           </td>
-          <td>
+<td>
            107
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-12.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1990", "1991", "1992", "1993", "1995"];
             const warData = [1.2, 0.8, 0.2, 0.1, -0.8];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "MIN"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MIN", "NYY"], "years": ["1992", "1991", "1995", "1990", "1993"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Kevin Maas", "hints": ["Set an MLB record as the fastest player to reach 15 career home runs, doing so in 133 at-bats.", "Finished second in the 1990 American League Rookie of the Year voting behind Sandy Alomar Jr.", "Played five professional seasons in Japan for the Hanshin Tigers and Chiba Lotte Marines."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-13.html
+++ b/2025-08-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-13" rel="canonical"/><meta content="Discover the career highlights and statistics for Jeff Reardon, the featured New York Yankee for the 2025-08-13 trivia puzzle." name="description"/>
+
+<title>
    Jeff Reardon Answer - August 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 13, 2025: Jeff Reardon. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-08-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jeff Reardon" src="images/answer-2025-08-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jeff Reardon" src="images/answer-2025-08-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jeff Reardon "The Terminator"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Became MLB's all-time saves leader in 1992, finishing with 367 career saves.
         </li>
-        <li>
+<li>
          Was the first pitcher to record 40-save seasons in both the American and National Leagues.
         </li>
-        <li>
+<li>
          Won a World Series championship with the 1987 Minnesota Twins.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Jeff Reardon?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Reardon was a model of consistency and durability, recording at least 30 saves in six different seasons during the 1980s. He was a four-time All-Star who combined an intimidating mound presence with a hard fastball and effective slider. His success with the Expos, Twins, and Red Sox made him one of the most reliable ninth-inning pitchers of his era.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Reardon was a model of consistency and durability, recording at least 30 saves in six different seasons during the 1980s. He was a four-time All-Star who combined an intimidating mound presence with a hard fastball and effective slider. His success with the Expos, Twins, and Red Sox made him one of the most reliable ninth-inning pitchers of his era.">
            How did Jeff Reardon establish himself as one of the premier closers of the 1980s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, Jeff Reardon's final major league season was a brief stint with the New York Yankees in 1994. He appeared in 11 games for the team, recording one save with an 8.38 ERA. He was released by the Yankees on May 6, 1994, which marked the end of his 16-year career.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, Jeff Reardon's final major league season was a brief stint with the New York Yankees in 1994. He appeared in 11 games for the team, recording one save with an 8.38 ERA. He was released by the Yankees on May 6, 1994, which marked the end of his 16-year career.">
            Did Jeff Reardon ever play for the Yankees or have any memorable moments with the team?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The nickname 'The Terminator' was given to him during his time with the Montreal Expos for his intimidating, no-nonsense demeanor on the mound. His thick beard, intense stare, and ability to shut down opponents in the ninth inning perfectly fit the image of a pitcher who 'terminated' the other team's hopes of a rally.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The nickname 'The Terminator' was given to him during his time with the Montreal Expos for his intimidating, no-nonsense demeanor on the mound. His thick beard, intense stare, and ability to shut down opponents in the ninth inning perfectly fit the image of a pitcher who 'terminated' the other team's hopes of a rally.">
            What was the story behind his nickname, 'The Terminator'?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            18.6
           </td>
-          <td>
+<td>
            73
           </td>
-          <td>
+<td>
            77
           </td>
-          <td>
+<td>
            3.16
           </td>
-          <td>
+<td>
            880
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            367
           </td>
-          <td>
+<td>
            1132.1
           </td>
-          <td>
+<td>
            877
           </td>
-          <td>
+<td>
            1.199
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994"];
             const warData = [0.4, 2.1, 2.0, 3.5, 0.9, 0.9, 1.1, 0.1, 0.7, 2.5, 1.1, 1.3, 1.5, 1.2, 0.0, -0.3];
             const teamsByYear = ["NYM", "NYM", "2TM", "MON", "MON", "MON", "MON", "MON", "MIN", "MIN", "MIN", "BOS", "BOS", "2TM", "CIN", "NYY"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MIN", "CIN", "BOS", "ATL", "MON", "NYY", "NYM"], "years": ["1983", "1988", "1986", "1992", "1994", "1981", "1991", "1984", "1985", "1987", "1989", "1979", "1980", "1990", "1993", "1982"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jeff Reardon", "hints": ["Became MLB's all-time saves leader in 1992, finishing with 367 career saves.", "Was the first pitcher to record 40-save seasons in both the American and National Leagues.", "Won a World Series championship with the 1987 Minnesota Twins."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-13.html
+++ b/2025-08-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jeff Reardon.">
   <title>
    Jeff Reardon Answer - August 13, 2025 | Name That Yankee
   </title>

--- a/2025-08-15.html
+++ b/2025-08-15.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-15" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Lindy McDaniel.">
   <title>
    Lindy McDaniel Answer - August 15, 2025 | Name That Yankee
   </title>

--- a/2025-08-15.html
+++ b/2025-08-15.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-15" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-15" rel="canonical"/><meta content="Discover the career highlights and statistics for Lindy McDaniel, the featured New York Yankee for the 2025-08-15 trivia puzzle." name="description"/>
+
+<title>
    Lindy McDaniel Answer - August 15, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 15, 2025: Lindy McDaniel. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 15, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-15.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 15, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-15.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 15, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-15.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 15, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-15.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,190 +42,190 @@
   "datePublished": "2025-08-15"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 15, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Lindy McDaniel" src="images/answer-2025-08-15.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Lindy McDaniel" src="images/answer-2025-08-15.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Lindy McDaniel "Lindy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Retired ranked second all-time in games pitched with 987.
         </li>
-        <li>
+<li>
          Finished third in the 1960 National League Cy Young Award voting as a relief pitcher.
         </li>
-        <li>
+<li>
          Was a teammate of his brother, Von McDaniel, on the St. Louis Cardinals.
         </li>
-       </ul>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+</ul>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            28.2
           </td>
-          <td>
+<td>
            141
           </td>
-          <td>
+<td>
            119
           </td>
-          <td>
+<td>
            3.45
           </td>
-          <td>
+<td>
            987
           </td>
-          <td>
+<td>
            74
           </td>
-          <td>
+<td>
            174
           </td>
-          <td>
+<td>
            2139.1
           </td>
-          <td>
+<td>
            1361
           </td>
-          <td>
+<td>
            1.272
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-15.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-15.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975"];
             const warData = [0.2, 0.6, 2.2, -0.9, 2.9, 5.9, -0.2, 0.7, 2.0, 1.1, 2.9, 1.6, 0.0, 2.0, 0.4, 4.2, -1.4, 0.9, 3.3, 1.1, -0.2];
             const teamsByYear = ["STL", "STL", "STL", "STL", "STL", "STL", "STL", "STL", "CHC", "CHC", "CHC", "SFG", "SFG", "2TM", "NYY", "NYY", "NYY", "NYY", "NYY", "KCR", "KCR"];
@@ -345,26 +346,26 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHC", "SFG", "KCR", "NYY", "STL"], "years": ["1962", "1966", "1973", "1955", "1960", "1974", "1967", "1968", "1958", "1975", "1963", "1970", "1964", "1971", "1969", "1959", "1956", "1957", "1965", "1972", "1961"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Lindy McDaniel", "hints": ["Retired ranked second all-time in games pitched with 987.", "Finished third in the 1960 National League Cy Young Award voting as a relief pitcher.", "Was a teammate of his brother, Von McDaniel, on the St. Louis Cardinals."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <footer>
-   <p class="disclaimer-footer">
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -375,11 +376,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-17.html
+++ b/2025-08-17.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-17" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-17" rel="canonical"/><meta content="Discover the career highlights and statistics for Bill White, the featured New York Yankee for the 2025-08-17 trivia puzzle." name="description"/>
+
+<title>
    Bill White Answer - August 17, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 17, 2025: Bill White. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 17, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-17.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 17, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-17.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 17, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-17.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 17, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-17.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-17"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 17, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bill White" src="images/answer-2025-08-17.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bill White" src="images/answer-2025-08-17.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bill White
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was an eight-time All-Star and a seven-time Gold Glove winner at first base.
         </li>
-        <li>
+<li>
          Became the first African American to serve as a league president in professional sports.
         </li>
-        <li>
+<li>
          Hit for the cycle in 1960 and collected 2,000 career hits in 1968.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Bill White?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Bill White was a highly respected first baseman for 13 seasons, primarily with the St. Louis Cardinals and Philadelphia Phillies. He was known for his exceptional defense and consistent bat, finishing with a .286 career batting average, 202 home runs, and 870 RBI. He was a key member of the Cardinals team that won the 1964 World Series.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Bill White was a highly respected first baseman for 13 seasons, primarily with the St. Louis Cardinals and Philadelphia Phillies. He was known for his exceptional defense and consistent bat, finishing with a .286 career batting average, 202 home runs, and 870 RBI. He was a key member of the Cardinals team that won the 1964 World Series.">
            What was Bill White's career like as a player?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, he had a very prominent role with the Yankees as a broadcaster. For 18 seasons, from 1971 to 1988, he was a play-by-play announcer on WPIX, where he formed a beloved and long-running broadcast team with Phil Rizzuto and Frank Messer.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, he had a very prominent role with the Yankees as a broadcaster. For 18 seasons, from 1971 to 1988, he was a play-by-play announcer on WPIX, where he formed a beloved and long-running broadcast team with Phil Rizzuto and Frank Messer.">
            Did Bill White have any connection to the Yankees after his playing days?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In 1989, Bill White was elected President of the National League, a position he held until 1994. This was a historic appointment, as he became the highest-ranking African American executive in professional sports at the time. During his tenure, he oversaw the NL's expansion with the addition of the Florida Marlins and Colorado Rockies.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In 1989, Bill White was elected President of the National League, a position he held until 1994. This was a historic appointment, as he became the highest-ranking African American executive in professional sports at the time. During his tenure, he oversaw the NL's expansion with the addition of the Florida Marlins and Colorado Rockies.">
            What was his most significant role in baseball after he stopped playing and broadcasting?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            38.6
           </td>
-          <td>
+<td>
            5972
           </td>
-          <td>
+<td>
            1706
           </td>
-          <td>
+<td>
            202
           </td>
-          <td>
+<td>
            .286
           </td>
-          <td>
+<td>
            843
           </td>
-          <td>
+<td>
            870
           </td>
-          <td>
+<td>
            103
           </td>
-          <td>
+<td>
            .351
           </td>
-          <td>
+<td>
            .455
           </td>
-          <td>
+<td>
            .806
           </td>
-          <td>
+<td>
            117
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-17.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-17.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1956", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969"];
             const warData = [3.1, 0.2, 2.2, 2.2, 2.6, 4.3, 6.0, 5.4, 5.4, 5.3, 1.2, 0.7, 0.1];
             const teamsByYear = ["NYG", "SFG", "STL", "STL", "STL", "STL", "STL", "STL", "STL", "PHI", "PHI", "PHI", "STL"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["STL", "PHI", "NYG", "SFG"], "years": ["1969", "1958", "1966", "1959", "1964", "1963", "1960", "1967", "1962", "1961", "1965", "1956", "1968"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bill White", "hints": ["Was an eight-time All-Star and a seven-time Gold Glove winner at first base.", "Became the first African American to serve as a league president in professional sports.", "Hit for the cycle in 1960 and collected 2,000 career hits in 1968."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-17.html
+++ b/2025-08-17.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-17" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bill White.">
   <title>
    Bill White Answer - August 17, 2025 | Name That Yankee
   </title>

--- a/2025-08-19.html
+++ b/2025-08-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bobby Richardson.">
   <title>
    Bobby Richardson Answer - August 19, 2025 | Name That Yankee
   </title>

--- a/2025-08-19.html
+++ b/2025-08-19.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Bobby Richardson, the featured New York Yankee for the 2025-08-19 trivia puzzle." name="description"/>
+
+<title>
    Bobby Richardson Answer - August 19, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 19, 2025: Bobby Richardson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 19, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 19, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-19.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 19, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 19, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-19.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-19"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 19, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bobby Richardson" src="images/answer-2025-08-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bobby Richardson" src="images/answer-2025-08-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bobby Richardson
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1960 World Series MVP award as a member of the losing team.
         </li>
-        <li>
+<li>
          Earned five consecutive Gold Glove Awards at second base from 1961 to 1965.
         </li>
-        <li>
+<li>
          Drove in a single-series record 12 runs during the 1960 World Series.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Bobby Richardson?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He was regarded as a premier defensive second baseman and a consistent contact hitter for the dominant Yankees teams of the early 1960s. While not a power threat, he was a durable player who led the American League in at-bats three times. His steady play and strong character made him a seven-time All-Star and a respected clubhouse presence.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="He was regarded as a premier defensive second baseman and a consistent contact hitter for the dominant Yankees teams of the early 1960s. While not a power threat, he was a durable player who led the American League in at-bats three times. His steady play and strong character made him a seven-time All-Star and a respected clubhouse presence.">
            What was Bobby Richardson's overall reputation as a player during his career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In Game 7 against the San Francisco Giants, with the Yankees clinging to a 1-0 lead in the bottom of the ninth, Richardson caught a screaming line drive hit by Willie McCovey. The catch ended the series and stranded runners on second and third, securing the championship for New York in one of the most dramatic finishes in World Series history.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In Game 7 against the San Francisco Giants, with the Yankees clinging to a 1-0 lead in the bottom of the ninth, Richardson caught a screaming line drive hit by Willie McCovey. The catch ended the series and stranded runners on second and third, securing the championship for New York in one of the most dramatic finishes in World Series history.">
            What is the story behind the final out of the 1962 World Series?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring at age 31 to spend more time with his family, Richardson became a successful college baseball coach. He led the University of South Carolina to its first College World Series finals appearance in 1975. He later coached at Coastal Carolina University and became a prominent public speaker for Christian organizations.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring at age 31 to spend more time with his family, Richardson became a successful college baseball coach. He led the University of South Carolina to its first College World Series finals appearance in 1975. He later coached at Coastal Carolina University and became a prominent public speaker for Christian organizations.">
            What did he do after his surprisingly early retirement from baseball?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            8.1
           </td>
-          <td>
+<td>
            5386
           </td>
-          <td>
+<td>
            1432
           </td>
-          <td>
+<td>
            34
           </td>
-          <td>
+<td>
            .266
           </td>
-          <td>
+<td>
            643
           </td>
-          <td>
+<td>
            390
           </td>
-          <td>
+<td>
            73
           </td>
-          <td>
+<td>
            .299
           </td>
-          <td>
+<td>
            .335
           </td>
-          <td>
+<td>
            .634
           </td>
-          <td>
+<td>
            77
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966"];
             const warData = [-0.7, -0.1, 0.2, 0.3, 2.2, 0.7, -0.7, 3.3, 2.5, 0.4, -1.0, 1.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1957", "1958", "1966", "1959", "1964", "1963", "1960", "1955", "1962", "1961", "1965", "1956"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bobby Richardson", "hints": ["Won the 1960 World Series MVP award as a member of the losing team.", "Earned five consecutive Gold Glove Awards at second base from 1961 to 1965.", "Drove in a single-series record 12 runs during the 1960 World Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-20.html
+++ b/2025-08-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-20" rel="canonical"/><meta content="Discover the career highlights and statistics for Phil Linz, the featured New York Yankee for the 2025-08-20 trivia puzzle." name="description"/>
+
+<title>
    Phil Linz Answer - August 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 20, 2025: Phil Linz. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Phil Linz" src="images/answer-2025-08-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Phil Linz" src="images/answer-2025-08-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Phil Linz
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a World Series championship as a rookie in 1962.
         </li>
-        <li>
+<li>
          Hit a go-ahead home run off Bob Gibson in Game 7 of the 1964 World Series.
         </li>
-        <li>
+<li>
          Appeared in three consecutive World Series from 1962 to 1964.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Phil Linz?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Phil Linz was a versatile utility infielder for the New York Yankees during their dynasty years of the early 1960s. He primarily served as a backup shortstop for Tony Kubek but also saw significant time at second and third base. His ability to play multiple positions made him a valuable role player on teams that reached the World Series three straight years.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Phil Linz was a versatile utility infielder for the New York Yankees during their dynasty years of the early 1960s. He primarily served as a backup shortstop for Tony Kubek but also saw significant time at second and third base. His ability to play multiple positions made him a valuable role player on teams that reached the World Series three straight years.">
            What was Phil Linz's primary role during his major league career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Linz had a memorable 1964 World Series, batting .259 with two home runs and four RBIs against the St. Louis Cardinals. Both of his home runs came off Hall of Fame pitcher Bob Gibson. His solo shot in Game 7 briefly gave the Yankees a lead before the Cardinals ultimately won the championship.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Linz had a memorable 1964 World Series, batting .259 with two home runs and four RBIs against the St. Louis Cardinals. Both of his home runs came off Hall of Fame pitcher Bob Gibson. His solo shot in Game 7 briefly gave the Yankees a lead before the Cardinals ultimately won the championship.">
            How did he perform in the 1964 World Series?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Following a tough loss in August 1964, Linz was playing his harmonica on the team bus when manager Yogi Berra told him to stop. Teammate Mickey Mantle jokingly told Linz that Berra had said to play it louder, which he did. This led to an angry confrontation, but the incident reportedly eased team tension and preceded a late-season surge to the pennant.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Following a tough loss in August 1964, Linz was playing his harmonica on the team bus when manager Yogi Berra told him to stop. Teammate Mickey Mantle jokingly told Linz that Berra had said to play it louder, which he did. This led to an angry confrontation, but the incident reportedly eased team tension and preceded a late-season surge to the pennant.">
            What is the story behind the famous 'harmonica incident'?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.1
           </td>
-          <td>
+<td>
            1372
           </td>
-          <td>
+<td>
            322
           </td>
-          <td>
+<td>
            11
           </td>
-          <td>
+<td>
            .235
           </td>
-          <td>
+<td>
            185
           </td>
-          <td>
+<td>
            96
           </td>
-          <td>
+<td>
            13
           </td>
-          <td>
+<td>
            .295
           </td>
-          <td>
+<td>
            .311
           </td>
-          <td>
+<td>
            .606
           </td>
-          <td>
+<td>
            72
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1962", "1963", "1964", "1965", "1966", "1967", "1968"];
             const warData = [0.3, 1.5, 2.7, -0.4, -0.7, -0.3, -1.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "PHI", "2TM", "NYM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYM", "NYY", "PHI"], "years": ["1964", "1963", "1967", "1962", "1966", "1965", "1968"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Phil Linz", "hints": ["Won a World Series championship as a rookie in 1962.", "Hit a go-ahead home run off Bob Gibson in Game 7 of the 1964 World Series.", "Appeared in three consecutive World Series from 1962 to 1964."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-20.html
+++ b/2025-08-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Phil Linz.">
   <title>
    Phil Linz Answer - August 20, 2025 | Name That Yankee
   </title>

--- a/2025-08-22.html
+++ b/2025-08-22.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-22" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Luis Tiant.">
   <title>
    Luis Tiant Answer - August 22, 2025 | Name That Yankee
   </title>

--- a/2025-08-22.html
+++ b/2025-08-22.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-22" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-22" rel="canonical"/><meta content="Discover the career highlights and statistics for Luis Tiant, the featured New York Yankee for the 2025-08-22 trivia puzzle." name="description"/>
+
+<title>
    Luis Tiant Answer - August 22, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 22, 2025: Luis Tiant. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 22, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-22.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 22, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-22.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 22, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-22.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 22, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-22.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-08-22"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 22, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Luis Tiant" src="images/answer-2025-08-22.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Luis Tiant" src="images/answer-2025-08-22.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Luis Tiant "El Tiante"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won two American League ERA titles, including a 1.60 ERA in 1968.
         </li>
-        <li>
+<li>
          Father, Luis Tiant Sr., was a star left-handed pitcher in the Negro Leagues.
         </li>
-        <li>
+<li>
          Threw two complete-game victories, including a shutout, in the 1975 World Series.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Luis Tiant?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His career featured two distinct peaks: first as a power pitcher in Cleveland and later as a crafty veteran in Boston. After injuries nearly ended his career, he reinvented himself and became a Red Sox icon, winning 20 or more games in three consecutive seasons from 1973 to 1976. His dramatic turnaround and clutch performances made him one of the most beloved players in franchise history.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="His career featured two distinct peaks: first as a power pitcher in Cleveland and later as a crafty veteran in Boston. After injuries nearly ended his career, he reinvented himself and became a Red Sox icon, winning 20 or more games in three consecutive seasons from 1973 to 1976. His dramatic turnaround and clutch performances made him one of the most beloved players in franchise history.">
            What made Luis Tiant's career so remarkable, especially his time with the Red Sox?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Tiant signed with the Yankees as a free agent and pitched for them for two seasons in 1979 and 1980. In his first year, he was a solid contributor to the rotation, posting a 13-8 record with a 3.91 ERA. His performance declined in his second season, and he did not pitch for the Yankees in the postseason.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Tiant signed with the Yankees as a free agent and pitched for them for two seasons in 1979 and 1980. In his first year, he was a solid contributor to the rotation, posting a 13-8 record with a 3.91 ERA. His performance declined in his second season, and he did not pitch for the Yankees in the postseason.">
            How did Luis Tiant perform during his time with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The ever-present cigar became Luis Tiant's trademark, reflecting his cool, charismatic personality on and off the field. He was rarely seen without one and famously quipped, &quot;If I smoke a cigar, I'm not hungry.&quot; The habit made him a larger-than-life figure, and he later launched his own cigar brand after his playing career.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The ever-present cigar became Luis Tiant's trademark, reflecting his cool, charismatic personality on and off the field. He was rarely seen without one and famously quipped, &quot;If I smoke a cigar, I'm not hungry.&quot; The habit made him a larger-than-life figure, and he later launched his own cigar brand after his playing career.">
            What was the story behind his famous cigar-smoking habit?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            66.1
           </td>
-          <td>
+<td>
            229
           </td>
-          <td>
+<td>
            172
           </td>
-          <td>
+<td>
            3.30
           </td>
-          <td>
+<td>
            573
           </td>
-          <td>
+<td>
            484
           </td>
-          <td>
+<td>
            15
           </td>
-          <td>
+<td>
            3486.1
           </td>
-          <td>
+<td>
            2416
           </td>
-          <td>
+<td>
            1.199
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-22.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-22.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982"];
             const warData = [3.9, 1.9, 4.1, 4.6, 8.5, 3.3, 1.2, -0.4, 6.5, 5.3, 7.7, 2.5, 6.3, 2.4, 5.6, 2.4, 0.2, 0.0, -0.3];
             const teamsByYear = ["CLE", "CLE", "CLE", "CLE", "CLE", "CLE", "MIN", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "NYY", "NYY", "PIT", "CAL"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "NYY", "CLE", "CAL", "PIT", "MIN"], "years": ["1979", "1968", "1969", "1970", "1973", "1972", "1971", "1978", "1974", "1975", "1964", "1977", "1967", "1966", "1976", "1981", "1982", "1980", "1965"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Luis Tiant", "hints": ["Won two American League ERA titles, including a 1.60 ERA in 1968.", "Father, Luis Tiant Sr., was a star left-handed pitcher in the Negro Leagues.", "Threw two complete-game victories, including a shutout, in the 1975 World Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-23.html
+++ b/2025-08-23.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Danny Cater, the featured New York Yankee for the 2025-08-23 trivia puzzle." name="description"/>
+
+<title>
    Danny Cater Answer - August 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 23, 2025: Danny Cater. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Danny Cater" src="images/answer-2025-08-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Danny Cater" src="images/answer-2025-08-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Danny Cater
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was named an American League All-Star in 1968.
         </li>
-        <li>
+<li>
          Led the American League with 36 doubles in 1968.
         </li>
-        <li>
+<li>
          Was the centerpiece of a trade to the New York Yankees for future Cy Young winner Sparky Lyle.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Danny Cater?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Danny Cater was a solid contact hitter known for consistently posting high batting averages and providing gap power. During his peak from 1966 to 1968, he hit .301, .290, and .290, making the All-Star team in his final year of that stretch. He was also a versatile defender, playing primarily first and third base but also seeing time in the outfield.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Danny Cater was a solid contact hitter known for consistently posting high batting averages and providing gap power. During his peak from 1966 to 1968, he hit .301, .290, and .290, making the All-Star team in his final year of that stretch. He was also a versatile defender, playing primarily first and third base but also seeing time in the outfield.">
            What kind of player was Danny Cater during his prime?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Cater's most notable achievement as a Yankee was a 21-game hitting streak during the 1970 season. The streak, which ran from August 28 to September 18, was the longest by a Yankee since Joe DiMaggio's 56-game streak in 1941. He batted .386 (34-for-88) during that impressive stretch.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Cater's most notable achievement as a Yankee was a 21-game hitting streak during the 1970 season. The streak, which ran from August 28 to September 18, was the longest by a Yankee since Joe DiMaggio's 56-game streak in 1941. He batted .386 (34-for-88) during that impressive stretch.">
            What was his most memorable achievement as a New York Yankee?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The trade is widely regarded as one of the best in Yankees history and one of the worst for the Athletics. While Cater was a solid player for two seasons in New York, Sparky Lyle became a dominant relief pitcher for the Yankees. Lyle would go on to win the 1977 AL Cy Young Award and two World Series championships with the team.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The trade is widely regarded as one of the best in Yankees history and one of the worst for the Athletics. While Cater was a solid player for two seasons in New York, Sparky Lyle became a dominant relief pitcher for the Yankees. Lyle would go on to win the 1977 AL Cy Young Award and two World Series championships with the team.">
            How is the trade that brought him to the Yankees remembered today?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            10.6
           </td>
-          <td>
+<td>
            4451
           </td>
-          <td>
+<td>
            1229
           </td>
-          <td>
+<td>
            66
           </td>
-          <td>
+<td>
            .276
           </td>
-          <td>
+<td>
            491
           </td>
-          <td>
+<td>
            519
           </td>
-          <td>
+<td>
            26
           </td>
-          <td>
+<td>
            .316
           </td>
-          <td>
+<td>
            .377
           </td>
-          <td>
+<td>
            .693
           </td>
-          <td>
+<td>
            101
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975"];
             const warData = [0.6, 2.0, 0.4, 0.6, 2.0, 0.5, 2.1, 0.7, 1.0, 0.6, 0.4, -0.3];
             const teamsByYear = ["PHI", "CHW", "2TM", "KCA", "OAK", "OAK", "NYY", "NYY", "BOS", "BOS", "BOS", "STL"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["BOS", "STL", "NYY", "OAK", "PHI", "KCA", "CHW"], "years": ["1969", "1970", "1975", "1964", "1973", "1972", "1971", "1967", "1974", "1966", "1965", "1968"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Danny Cater", "hints": ["Was named an American League All-Star in 1968.", "Led the American League with 36 doubles in 1968.", "Was the centerpiece of a trade to the New York Yankees for future Cy Young winner Sparky Lyle."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-23.html
+++ b/2025-08-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Danny Cater.">
   <title>
    Danny Cater Answer - August 23, 2025 | Name That Yankee
   </title>

--- a/2025-08-25.html
+++ b/2025-08-25.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-25" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Tim Raines.">
   <title>
    Tim Raines Answer - August 25, 2025 | Name That Yankee
   </title>

--- a/2025-08-25.html
+++ b/2025-08-25.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-25" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-25" rel="canonical"/><meta content="Discover the career highlights and statistics for Tim Raines, the featured New York Yankee for the 2025-08-25 trivia puzzle." name="description"/>
+
+<title>
    Tim Raines Answer - August 25, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 25, 2025: Tim Raines. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 25, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-25.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 25, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-25.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 25, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-25.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 25, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-25.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-25"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 25, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Tim Raines" src="images/answer-2025-08-25.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Tim Raines" src="images/answer-2025-08-25.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Tim Raines "Rock"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Holds the best stolen base success rate (84.7%) among players with at least 400 attempts.
         </li>
-        <li>
+<li>
          Won the 1986 National League batting title with a .334 average.
         </li>
-        <li>
+<li>
          Was selected as an All-Star in seven consecutive seasons from 1981 to 1987.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Tim Raines?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Tim Raines was an elite on-base machine, finishing his career with a .385 on-base percentage and 1,330 walks. As a switch-hitter, he consistently set the table for his teams, scoring 1,571 runs, which ranks among the top 50 all-time. His combination of hitting for average, drawing walks, and exceptional baserunning made him one of the most dynamic leadoff hitters in history.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Tim Raines was an elite on-base machine, finishing his career with a .385 on-base percentage and 1,330 walks. As a switch-hitter, he consistently set the table for his teams, scoring 1,571 runs, which ranks among the top 50 all-time. His combination of hitting for average, drawing walks, and exceptional baserunning made him one of the most dynamic leadoff hitters in history.">
            Besides his speed, what made Tim Raines a Hall of Fame-caliber player?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Raines served as a veteran designated hitter and left fielder, winning two World Series rings with the Yankees in 1996 and 1998. In the 1996 postseason, he hit .444 in the ALDS before a hamstring injury sidelined him for the World Series. He returned in 1998 as a valuable role player, hitting a crucial three-run home run in Game 3 of the ALCS against Cleveland.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Raines served as a veteran designated hitter and left fielder, winning two World Series rings with the Yankees in 1996 and 1998. In the 1996 postseason, he hit .444 in the ALDS before a hamstring injury sidelined him for the World Series. He returned in 1998 as a valuable role player, hitting a crucial three-run home run in Game 3 of the ALCS against Cleveland.">
            What was his role on the Yankees' World Series championship teams?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, during the early part of his career when he was struggling with cocaine addiction, Raines admitted to carrying a vial of the drug in his back pocket during games. He famously began sliding headfirst to avoid breaking the vial upon impact. He overcame his addiction after the 1982 season and went on to have a Hall of Fame career.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, during the early part of his career when he was struggling with cocaine addiction, Raines admitted to carrying a vial of the drug in his back pocket during games. He famously began sliding headfirst to avoid breaking the vial upon impact. He overcame his addiction after the 1982 season and went on to have a Hall of Fame career.">
            Is it true he had a unique way of sliding to protect something he carried in his pocket?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            69.5
           </td>
-          <td>
+<td>
            8872
           </td>
-          <td>
+<td>
            2605
           </td>
-          <td>
+<td>
            170
           </td>
-          <td>
+<td>
            .294
           </td>
-          <td>
+<td>
            1571
           </td>
-          <td>
+<td>
            980
           </td>
-          <td>
+<td>
            808
           </td>
-          <td>
+<td>
            .385
           </td>
-          <td>
+<td>
            .425
           </td>
-          <td>
+<td>
            .810
           </td>
-          <td>
+<td>
            123
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-25.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-25.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2001", "2002"];
             const warData = [0.0, -0.1, 3.5, 2.8, 6.0, 6.5, 7.6, 5.5, 6.8, 3.6, 3.7, 2.9, 3.2, 6.3, 3.8, 1.8, 1.5, 1.1, 1.4, 0.9, 0.3, 0.6, -0.1];
             const teamsByYear = ["MON", "MON", "MON", "MON", "MON", "MON", "MON", "MON", "MON", "MON", "MON", "MON", "CHW", "CHW", "CHW", "CHW", "CHW", "NYY", "NYY", "NYY", "OAK", "2TM", "FLA"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["MON", "BAL", "NYY", "OAK", "FLA", "CHW"], "years": ["2001", "1999", "1996", "1987", "1979", "1991", "1993", "2002", "1984", "1989", "1986", "1992", "1983", "1997", "1988", "1995", "1998", "1990", "1994", "1985", "1981", "1982", "1980"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Tim Raines", "hints": ["Holds the best stolen base success rate (84.7%) among players with at least 400 attempts.", "Won the 1986 National League batting title with a .334 average.", "Was selected as an All-Star in seven consecutive seasons from 1981 to 1987."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-26.html
+++ b/2025-08-26.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-26" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ricky Bones.">
   <title>
    Ricky Bones Answer - August 26, 2025 | Name That Yankee
   </title>

--- a/2025-08-26.html
+++ b/2025-08-26.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-26" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-26" rel="canonical"/><meta content="Discover the career highlights and statistics for Ricky Bones, the featured New York Yankee for the 2025-08-26 trivia puzzle." name="description"/>
+
+<title>
    Ricky Bones Answer - August 26, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 26, 2025: Ricky Bones. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 26, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-26.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 26, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-26.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 26, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-26.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 26, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-26.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-08-26"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 26, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ricky Bones" src="images/answer-2025-08-26.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ricky Bones" src="images/answer-2025-08-26.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ricky Bones
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a 1994 American League All-Star with the Milwaukee Brewers.
         </li>
-        <li>
+<li>
          Pitched for Puerto Rico in the 1988 Summer Olympics.
         </li>
-        <li>
+<li>
          Played for nine different MLB teams over an 11-season career.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Ricky Bones?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He began his career as a starting pitcher, most successfully with the Milwaukee Brewers, where he was an All-Star in 1994. Later in his career, he transitioned into a durable relief pitcher known for his sinker. He was a quintessential journeyman, valued for his versatility and ability to pitch in various roles for many different clubs.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="He began his career as a starting pitcher, most successfully with the Milwaukee Brewers, where he was an All-Star in 1994. Later in his career, he transitioned into a durable relief pitcher known for his sinker. He was a quintessential journeyman, valued for his versatility and ability to pitch in various roles for many different clubs.">
            What was Ricky Bones's role during his career and what was he best known for?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, he pitched effectively for the Yankees during their 1997 postseason run. He appeared in two games of the American League Division Series against Cleveland, throwing 2.1 scoreless innings in relief. Though the Yankees ultimately lost the series, his performance was a reliable contribution from the bullpen.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, he pitched effectively for the Yankees during their 1997 postseason run. He appeared in two games of the American League Division Series against Cleveland, throwing 2.1 scoreless innings in relief. Though the Yankees ultimately lost the series, his performance was a reliable contribution from the bullpen.">
            Did Ricky Bones have any memorable moments during his brief time with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring as a player, he became a highly respected pitching coach. He served as the bullpen coach for the New York Mets for seven seasons (2012-2018) and has also coached for the Washington Nationals. Additionally, he has been a key coach for the Puerto Rican national team in multiple World Baseball Classic tournaments.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring as a player, he became a highly respected pitching coach. He served as the bullpen coach for the New York Mets for seven seasons (2012-2018) and has also coached for the Washington Nationals. Additionally, he has been a key coach for the Puerto Rican national team in multiple World Baseball Classic tournaments.">
            What has Ricky Bones done since his playing career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.9
           </td>
-          <td>
+<td>
            63
           </td>
-          <td>
+<td>
            82
           </td>
-          <td>
+<td>
            4.85
           </td>
-          <td>
+<td>
            375
           </td>
-          <td>
+<td>
            164
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            1278.1
           </td>
-          <td>
+<td>
            564
           </td>
-          <td>
+<td>
            1.475
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-26.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-26.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [-0.4, 0.3, 0.7, 4.0, 3.4, -0.2, -1.6, 1.4, -0.2, 0.2, -0.5];
             const teamsByYear = ["SDP", "MIL", "MIL", "MIL", "MIL", "2TM", "2TM", "KCR", "BAL", "FLA", "FLA"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SDP", "NYY", "CIN", "BAL", "KCR", "FLA", "MIL"], "years": ["2001", "1991", "1993", "1997", "1999", "1995", "1998", "1994", "1992", "1996", "2000"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ricky Bones", "hints": ["Was a 1994 American League All-Star with the Milwaukee Brewers.", "Pitched for Puerto Rico in the 1988 Summer Olympics.", "Played for nine different MLB teams over an 11-season career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-27.html
+++ b/2025-08-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Graig Nettles, the featured New York Yankee for the 2025-08-27 trivia puzzle." name="description"/>
+
+<title>
    Graig Nettles Answer - August 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 27, 2025: Graig Nettles. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Graig Nettles" src="images/answer-2025-08-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Graig Nettles" src="images/answer-2025-08-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Graig Nettles "Puff"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Holds the American League record for career home runs by a third baseman with 319.
         </li>
-        <li>
+<li>
          Won two Gold Glove Awards at third base.
         </li>
-        <li>
+<li>
          Served as captain of the New York Yankees from 1982 to 1984.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Graig Nettles?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Nettles was a six-time All-Star and a durable team leader who played 22 seasons in the major leagues. His combination of consistent power, elite defense, and clubhouse presence made him a cornerstone player for multiple pennant-winning teams. He finished in the top 10 of MVP voting three times, highlighting his all-around impact.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Nettles was a six-time All-Star and a durable team leader who played 22 seasons in the major leagues. His combination of consistent power, elite defense, and clubhouse presence made him a cornerstone player for multiple pennant-winning teams. He finished in the top 10 of MVP voting three times, highlighting his all-around impact.">
            Besides his power and defense, what made Graig Nettles such a valuable player for so long?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In Game 3 against the Los Angeles Dodgers, Nettles put on a defensive clinic, making a series of spectacular diving stops to rob the Dodgers of multiple hits and runs. His incredible play at third base is widely credited with saving the game and turning the momentum of the entire series. The Yankees, down 0-2, came back to win the championship in six games.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In Game 3 against the Los Angeles Dodgers, Nettles put on a defensive clinic, making a series of spectacular diving stops to rob the Dodgers of multiple hits and runs. His incredible play at third base is widely credited with saving the game and turning the momentum of the entire series. The Yankees, down 0-2, came back to win the championship in six games.">
            What made his defensive performance in the 1978 World Series so famous?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, he was famous for his sharp, sarcastic wit and was one of baseball's most quotable players. He co-authored a controversial and humorous tell-all book titled &quot;Balls&quot; in 1984, which candidly detailed his experiences and opinions about teammates and management. His outspoken nature and dry humor made him a memorable figure throughout his career.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, he was famous for his sharp, sarcastic wit and was one of baseball's most quotable players. He co-authored a controversial and humorous tell-all book titled &quot;Balls&quot; in 1984, which candidly detailed his experiences and opinions about teammates and management. His outspoken nature and dry humor made him a memorable figure throughout his career.">
            Was Graig Nettles known for having a particularly interesting personality off the field?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            68.0
           </td>
-          <td>
+<td>
            8986
           </td>
-          <td>
+<td>
            2225
           </td>
-          <td>
+<td>
            390
           </td>
-          <td>
+<td>
            .248
           </td>
-          <td>
+<td>
            1193
           </td>
-          <td>
+<td>
            1314
           </td>
-          <td>
+<td>
            32
           </td>
-          <td>
+<td>
            .329
           </td>
-          <td>
+<td>
            .421
           </td>
-          <td>
+<td>
            .750
           </td>
-          <td>
+<td>
            110
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988"];
             const warData = [0.0, 0.4, 0.6, 5.2, 7.5, 4.8, 5.6, 4.9, 4.7, 8.0, 5.5, 5.7, 2.7, 1.4, 2.7, 0.8, 2.5, 2.3, 3.3, 0.3, -0.1, -0.8];
             const teamsByYear = ["MIN", "MIN", "MIN", "CLE", "CLE", "CLE", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "SDP", "SDP", "SDP", "ATL", "MON"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["ATL", "MIN", "NYY", "SDP", "MON", "CLE"], "years": ["1987", "1979", "1968", "1969", "1970", "1984", "1973", "1972", "1971", "1978", "1986", "1974", "1975", "1983", "1988", "1977", "1985", "1967", "1976", "1981", "1982", "1980"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Graig Nettles", "hints": ["Holds the American League record for career home runs by a third baseman with 319.", "Won two Gold Glove Awards at third base.", "Served as captain of the New York Yankees from 1982 to 1984."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-27.html
+++ b/2025-08-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Graig Nettles.">
   <title>
    Graig Nettles Answer - August 27, 2025 | Name That Yankee
   </title>

--- a/2025-08-28.html
+++ b/2025-08-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Dan Pasqua, the featured New York Yankee for the 2025-08-28 trivia puzzle." name="description"/>
+
+<title>
    Dan Pasqua Answer - August 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 28, 2025: Dan Pasqua. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Dan Pasqua" src="images/answer-2025-08-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Dan Pasqua" src="images/answer-2025-08-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Dan Pasqua
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was a key piece in the November 1987 trade that sent Rickey Henderson from New York to Oakland.
         </li>
-        <li>
+<li>
          Hit 16 home runs in only 92 games as a rookie in 1986.
         </li>
-        <li>
+<li>
          Homered in the 1993 American League Championship Series against the Toronto Blue Jays.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Dan Pasqua?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Dan Pasqua was known as a power-hitting outfielder with an all-or-nothing approach at the plate. He possessed significant home run power but also struck out frequently and posted low batting averages, never hitting above .262 in a full season. This profile made him a valuable platoon player, particularly against right-handed pitching, during his time with the Yankees and later the White Sox.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Dan Pasqua was known as a power-hitting outfielder with an all-or-nothing approach at the plate. He possessed significant home run power but also struck out frequently and posted low batting averages, never hitting above .262 in a full season. This profile made him a valuable platoon player, particularly against right-handed pitching, during his time with the Yankees and later the White Sox.">
            What was Dan Pasqua's reputation as a major league player?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His most notable Yankees season was his 1986 rookie campaign, where he showed immense promise as a power hitter. In just 92 games, he hit 16 home runs and drove in 47 runs with a solid .832 OPS. This performance established him as a key young power bat alongside Don Mattingly and Dave Winfield in the New York lineup.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="His most notable Yankees season was his 1986 rookie campaign, where he showed immense promise as a power hitter. In just 92 games, he hit 16 home runs and drove in 47 runs with a solid .832 OPS. This performance established him as a key young power bat alongside Don Mattingly and Dave Winfield in the New York lineup.">
            What was his most notable season as a New York Yankee?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring from baseball in 1994, Pasqua returned to his hometown of Oradell, New Jersey, and entered the business world. He became an executive for a construction company, a field he has worked in for many years. This marked a distinct transition away from the sport following his 10-year major league career.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring from baseball in 1994, Pasqua returned to his hometown of Oradell, New Jersey, and entered the business world. He became an executive for a construction company, a field he has worked in for many years. This marked a distinct transition away from the sport following his 10-year major league career.">
            What did Dan Pasqua do after his baseball career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            10.7
           </td>
-          <td>
+<td>
            2620
           </td>
-          <td>
+<td>
            638
           </td>
-          <td>
+<td>
            117
           </td>
-          <td>
+<td>
            .244
           </td>
-          <td>
+<td>
            341
           </td>
-          <td>
+<td>
            390
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            .330
           </td>
-          <td>
+<td>
            .438
           </td>
-          <td>
+<td>
            .768
           </td>
-          <td>
+<td>
            112
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994"];
             const warData = [0.5, 2.5, 0.0, 1.9, 1.1, 2.4, 2.4, -0.1, 0.1, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW"], "years": ["1987", "1985", "1990", "1991", "1992", "1994", "1988", "1986", "1989", "1993"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Dan Pasqua", "hints": ["Was a key piece in the November 1987 trade that sent Rickey Henderson from New York to Oakland.", "Hit 16 home runs in only 92 games as a rookie in 1986.", "Homered in the 1993 American League Championship Series against the Toronto Blue Jays."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-28.html
+++ b/2025-08-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Dan Pasqua.">
   <title>
    Dan Pasqua Answer - August 28, 2025 | Name That Yankee
   </title>

--- a/2025-08-29.html
+++ b/2025-08-29.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-29" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-29" rel="canonical"/><meta content="Discover the career highlights and statistics for Ron Kittle, the featured New York Yankee for the 2025-08-29 trivia puzzle." name="description"/>
+
+<title>
    Ron Kittle Answer - August 29, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 29, 2025: Ron Kittle. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 29, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-29.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 29, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-29.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 29, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-29.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 29, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-29.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-29"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 29, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ron Kittle" src="images/answer-2025-08-29.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ron Kittle" src="images/answer-2025-08-29.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ron Kittle "Kitty"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Named the 1983 American League Rookie of the Year.
         </li>
-        <li>
+<li>
          Selected as an All-Star while hitting 35 home runs and collecting 100 RBI as a rookie.
         </li>
-        <li>
+<li>
          Hit three career home runs onto the roof of the original Comiskey Park.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Ron Kittle?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Kittle's 1983 rookie season with the &quot;Winning Ugly&quot; Chicago White Sox was phenomenal, as he won Rookie of the Year by hitting 35 home runs with 100 RBI. His immense power made him an instant star, but a series of injuries, particularly to his back, limited his playing time and effectiveness over the following years. He had several stints with the White Sox and other clubs but never fully replicated the sustained success of his incredible debut.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Kittle's 1983 rookie season with the &quot;Winning Ugly&quot; Chicago White Sox was phenomenal, as he won Rookie of the Year by hitting 35 home runs with 100 RBI. His immense power made him an instant star, but a series of injuries, particularly to his back, limited his playing time and effectiveness over the following years. He had several stints with the White Sox and other clubs but never fully replicated the sustained success of his incredible debut.">
            What made Ron Kittle's rookie season so spectacular, and how did the rest of his career unfold?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Kittle played parts of two seasons with the New York Yankees in 1986 and 1987 after being acquired in a trade from the White Sox. He served primarily as a designated hitter and platoon outfielder, hitting a combined 18 home runs in 90 games for the club. His time in New York was relatively brief, as he was traded to the Cleveland Indians during the 1987 season.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Kittle played parts of two seasons with the New York Yankees in 1986 and 1987 after being acquired in a trade from the White Sox. He served primarily as a designated hitter and platoon outfielder, hitting a combined 18 home runs in 90 games for the club. His time in New York was relatively brief, as he was traded to the Cleveland Indians during the 1987 season.">
            What was Ron Kittle's time with the Yankees like?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Kittle was known for his blue-collar work ethic and fan-friendly personality, which stemmed from his pre-baseball career as an ironworker. He was a notorious clubhouse prankster and storyteller, once famously setting off a cherry bomb in teammate Carlton Fisk's cowboy boot. After his playing career, he founded an Indiana-based company specializing in steel fabrication and construction.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Kittle was known for his blue-collar work ethic and fan-friendly personality, which stemmed from his pre-baseball career as an ironworker. He was a notorious clubhouse prankster and storyteller, once famously setting off a cherry bomb in teammate Carlton Fisk's cowboy boot. After his playing career, he founded an Indiana-based company specializing in steel fabrication and construction.">
            I heard Ron Kittle had a reputation for being a character; what was he like off the field?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.7
           </td>
-          <td>
+<td>
            2708
           </td>
-          <td>
+<td>
            648
           </td>
-          <td>
+<td>
            176
           </td>
-          <td>
+<td>
            .239
           </td>
-          <td>
+<td>
            356
           </td>
-          <td>
+<td>
            460
           </td>
-          <td>
+<td>
            16
           </td>
-          <td>
+<td>
            .306
           </td>
-          <td>
+<td>
            .473
           </td>
-          <td>
+<td>
            .779
           </td>
-          <td>
+<td>
            110
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-29.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-29.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [-0.1, 1.9, 0.6, 0.4, -1.0, 0.2, 1.1, 1.6, 0.1, -0.1];
             const teamsByYear = ["CHW", "CHW", "CHW", "CHW", "2TM", "NYY", "CLE", "CHW", "2TM", "CHW"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYY", "BAL", "CHW"], "years": ["1987", "1985", "1990", "1984", "1991", "1983", "1982", "1988", "1986", "1989"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ron Kittle", "hints": ["Named the 1983 American League Rookie of the Year.", "Selected as an All-Star while hitting 35 home runs and collecting 100 RBI as a rookie.", "Hit three career home runs onto the roof of the original Comiskey Park."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-29.html
+++ b/2025-08-29.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-29" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ron Kittle.">
   <title>
    Ron Kittle Answer - August 29, 2025 | Name That Yankee
   </title>

--- a/2025-08-30.html
+++ b/2025-08-30.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-30" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Andrew Arthur Carey.">
   <title>
    Andrew Arthur Carey Answer - August 30, 2025 | Name That Yankee
   </title>

--- a/2025-08-30.html
+++ b/2025-08-30.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-30" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-30" rel="canonical"/><meta content="Discover the career highlights and statistics for Andrew Arthur Carey, the featured New York Yankee for the 2025-08-30 trivia puzzle." name="description"/>
+
+<title>
    Andrew Arthur Carey Answer - August 30, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 30, 2025: Andrew Arthur Carey. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 30, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-30.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 30, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-30.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 30, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 30, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-30.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-08-30"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 30, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Andrew Arthur Carey" src="images/answer-2025-08-30.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Andrew Arthur Carey" src="images/answer-2025-08-30.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Andrew Arthur Carey "Handy Andy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Played third base in four consecutive World Series from 1955 to 1958.
         </li>
-        <li>
+<li>
          Was a second-generation major leaguer, as his father Joe played for the Washington Senators.
         </li>
-        <li>
+<li>
          Served two years in the U.S. Army during the Korean War, missing the 1952 and 1953 seasons.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Andrew Arthur Carey?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Andy Carey was the Yankees' primary starting third baseman from 1954 through mid-1958, providing solid defense at the hot corner. While surrounded by Hall of Fame sluggers, he was a dependable bat in the lineup. His best offensive season came in his 1954 rookie campaign when he hit .302 with 65 RBI.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Andy Carey was the Yankees' primary starting third baseman from 1954 through mid-1958, providing solid defense at the hot corner. While surrounded by Hall of Fame sluggers, he was a dependable bat in the lineup. His best offensive season came in his 1954 rookie campaign when he hit .302 with 65 RBI.">
            What was Andy Carey's role on those great Yankees teams of the 1950s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His most significant World Series hit was a two-run home run off Sal Maglie in Game 1 of the 1956 World Series against the Brooklyn Dodgers. He also hit a solo home run in the decisive Game 7 of the 1957 World Series, though the Yankees lost that game to the Milwaukee Braves. Across his four World Series appearances, he collected 19 hits.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="His most significant World Series hit was a two-run home run off Sal Maglie in Game 1 of the 1956 World Series against the Brooklyn Dodgers. He also hit a solo home run in the decisive Game 7 of the 1957 World Series, though the Yankees lost that game to the Milwaukee Braves. Across his four World Series appearances, he collected 19 hits.">
            Did Carey have any memorable World Series moments with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Despite the shared surname, Andy Carey was not related to Hall of Famer Max Carey or his son Scoop Carey. However, baseball did run in the family. He was a second-generation major leaguer, as his father, Joe Carey, was a catcher who played for the Washington Senators in 1924.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Despite the shared surname, Andy Carey was not related to Hall of Famer Max Carey or his son Scoop Carey. However, baseball did run in the family. He was a second-generation major leaguer, as his father, Joe Carey, was a catcher who played for the Washington Senators in 1924.">
            Was he related to the Hall of Famer Max Carey?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            9.9
           </td>
-          <td>
+<td>
            2850
           </td>
-          <td>
+<td>
            741
           </td>
-          <td>
+<td>
            64
           </td>
-          <td>
+<td>
            .260
           </td>
-          <td>
+<td>
            371
           </td>
-          <td>
+<td>
            350
           </td>
-          <td>
+<td>
            23
           </td>
-          <td>
+<td>
            .327
           </td>
-          <td>
+<td>
            .396
           </td>
-          <td>
+<td>
            .722
           </td>
-          <td>
+<td>
            97
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-30.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962"];
             const warData = [-0.6, 1.0, 3.2, 1.6, -0.1, 0.8, 3.2, 0.1, 0.3, 0.4, 0.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "2TM", "LAD"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "KCA", "LAD", "CHW"], "years": ["1959", "1961", "1953", "1954", "1956", "1960", "1962", "1957", "1958", "1955", "1952"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Andrew Arthur Carey", "hints": ["Played third base in four consecutive World Series from 1955 to 1958.", "Was a second-generation major leaguer, as his father Joe played for the Washington Senators.", "Served two years in the U.S. Army during the Korean War, missing the 1952 and 1953 seasons."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-31.html
+++ b/2025-08-31.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-08-31" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-08-31" rel="canonical"/><meta content="Discover the career highlights and statistics for Orlando Hernández, the featured New York Yankee for the 2025-08-31 trivia puzzle." name="description"/>
+
+<title>
    Orlando Hernández Answer - August 31, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on August 31, 2025: Orlando Hernández. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - August 31, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-08-31.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - August 31, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-08-31.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - August 31, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-08-31.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - August 31, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-08-31.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-08-31"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for August 31, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Orlando Hernández" src="images/answer-2025-08-31.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Orlando Hernández" src="images/answer-2025-08-31.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Orlando Hernández "El Duque"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Debuted in the major leagues at the age of 32.
         </li>
-        <li>
+<li>
          Was named the 1999 American League Championship Series MVP.
         </li>
-        <li>
+<li>
          Is the older half-brother of 1997 World Series MVP Liván Hernández.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Orlando Hernández?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After being a star pitcher for the Cuban national team, he was banned from Cuban baseball for life in 1996 after his half-brother Liván defected. In 1997, he escaped Cuba on a small boat, was detained in the Bahamas, and was eventually granted a visa to come to the United States, where he signed with the New York Yankees as a 32-year-old rookie.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After being a star pitcher for the Cuban national team, he was banned from Cuban baseball for life in 1996 after his half-brother Liván defected. In 1997, he escaped Cuba on a small boat, was detained in the Bahamas, and was eventually granted a visa to come to the United States, where he signed with the New York Yankees as a 32-year-old rookie.">
            What made his journey to the major leagues so remarkable?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="He began his career by winning his first eight postseason decisions, a major league record at the time. As a Yankee, he posted a 9-3 record with a 2.65 ERA in 17 postseason appearances, winning three World Series rings. His signature performance was in the 1999 ALCS against Boston, where he allowed just one run in Game 1 and pitched seven shutout innings in the deciding Game 5.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="He began his career by winning his first eight postseason decisions, a major league record at the time. As a Yankee, he posted a 9-3 record with a 2.65 ERA in 17 postseason appearances, winning three World Series rings. His signature performance was in the 1999 ALCS against Boston, where he allowed just one run in Game 1 and pitched seven shutout innings in the deciding Game 5.">
            How did he earn his reputation as a clutch postseason pitcher for the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The nickname 'El Duque' (The Duke) was inherited from his father, Arnaldo Hernández, who was a famous pitcher in Cuba. His iconic, sky-high leg kick was a deceptive and intimidating delivery style he developed to disrupt hitters' timing and hide the baseball until the last possible moment.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The nickname 'El Duque' (The Duke) was inherited from his father, Arnaldo Hernández, who was a famous pitcher in Cuba. His iconic, sky-high leg kick was a deceptive and intimidating delivery style he developed to disrupt hitters' timing and hide the baseball until the last possible moment.">
            Why was he nicknamed 'El Duque' and known for that high leg kick?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            23.1
           </td>
-          <td>
+<td>
            90
           </td>
-          <td>
+<td>
            65
           </td>
-          <td>
+<td>
            4.13
           </td>
-          <td>
+<td>
            219
           </td>
-          <td>
+<td>
            211
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            1314.2
           </td>
-          <td>
+<td>
            1086
           </td>
-          <td>
+<td>
            1.263
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-08-31.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-08-31.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1998", "1999", "2000", "2001", "2002", "2004", "2005", "2006", "2007"];
             const warData = [3.6, 4.2, 3.2, 1.4, 3.7, 2.8, 0.4, 1.2, 2.5];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CHW", "2TM", "NYM"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CHW", "ARI", "NYM", "NYY"], "years": ["2004", "2006", "2002", "2001", "1999", "1998", "2007", "2000", "2005"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Orlando Hern\u00e1ndez", "hints": ["Debuted in the major leagues at the age of 32.", "Was named the 1999 American League Championship Series MVP.", "Is the older half-brother of 1997 World Series MVP Liv\u00e1n Hern\u00e1ndez."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-08-31.html
+++ b/2025-08-31.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-08-31" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Orlando Hern\u00e1ndez.">
   <title>
    Orlando Hernández Answer - August 31, 2025 | Name That Yankee
   </title>

--- a/2025-09-02.html
+++ b/2025-09-02.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-02" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-02" rel="canonical"/><meta content="Discover the career highlights and statistics for Marwin González, the featured New York Yankee for the 2025-09-02 trivia puzzle." name="description"/>
+
+<title>
    Marwin González Answer - September 02, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 02, 2025: Marwin González. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 02, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-02.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 02, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-02.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 02, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-02.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 02, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-02.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-02"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 02, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Marwin González" src="images/answer-2025-09-02.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Marwin González" src="images/answer-2025-09-02.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Marwin González
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the first player to start at five different positions in the first five games of a World Series.
         </li>
-        <li>
+<li>
          Hit the first grand slam in Houston Astros World Series history.
         </li>
-        <li>
+<li>
          Hit a home run for first career major league hit.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Marwin González?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="González's primary value came from his incredible defensive flexibility, as he played every infield and outfield position during his career. He was also a switch-hitter, allowing managers to use him in various lineup spots against both right- and left-handed pitching. In his peak 2017 season with the Astros, he combined this flexibility with significant power, hitting 23 home runs with 90 RBI and a .907 OPS.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="González's primary value came from his incredible defensive flexibility, as he played every infield and outfield position during his career. He was also a switch-hitter, allowing managers to use him in various lineup spots against both right- and left-handed pitching. In his peak 2017 season with the Astros, he combined this flexibility with significant power, hitting 23 home runs with 90 RBI and a .907 OPS.">
            Besides his famous World Series versatility, what made Marwin González such a uniquely valuable player for the teams he was on?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="González's most memorable moment as a Yankee came on May 10, 2022, against the Toronto Blue Jays. With the bases loaded and one out in the bottom of the ninth inning, he hit a walk-off RBI single off pitcher Jordan Romano to give the Yankees a 6-5 victory. It was his only walk-off hit during his single season in New York.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="González's most memorable moment as a Yankee came on May 10, 2022, against the Toronto Blue Jays. With the bases loaded and one out in the bottom of the ninth inning, he hit a walk-off RBI single off pitcher Jordan Romano to give the Yankees a 6-5 victory. It was his only walk-off hit during his single season in New York.">
            What was Marwin González's most significant hit during his time with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, Marwin González named his son Brooks after Hall of Fame third baseman Brooks Robinson. González admired the legendary Oriole's defensive prowess and character. He even had the opportunity to meet Robinson in 2018, calling it a dream come true.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, Marwin González named his son Brooks after Hall of Fame third baseman Brooks Robinson. González admired the legendary Oriole's defensive prowess and character. He even had the opportunity to meet Robinson in 2018, calling it a dream come true.">
            Is there a special story behind the name of Marwin González's son?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.5
           </td>
-          <td>
+<td>
            3526
           </td>
-          <td>
+<td>
            888
           </td>
-          <td>
+<td>
            107
           </td>
-          <td>
+<td>
            .252
           </td>
-          <td>
+<td>
            420
           </td>
-          <td>
+<td>
            415
           </td>
-          <td>
+<td>
            44
           </td>
-          <td>
+<td>
            .310
           </td>
-          <td>
+<td>
            .399
           </td>
-          <td>
+<td>
            .709
           </td>
-          <td>
+<td>
            94
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-02.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-02.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022"];
             const warData = [-0.1, 0.7, 1.3, 2.7, 1.4, 4.1, 2.5, 2.0, 0.2, -0.8, 0.6];
             const teamsByYear = ["HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "MIN", "MIN", "2TM", "NYY"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["HOU", "MIN", "BOS", "NYY"], "years": ["2016", "2014", "2013", "2021", "2015", "2018", "2020", "2017", "2022", "2019", "2012"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Marwin Gonz\u00e1lez", "hints": ["Was the first player to start at five different positions in the first five games of a World Series.", "Hit the first grand slam in Houston Astros World Series history.", "Hit a home run for first career major league hit."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-02.html
+++ b/2025-09-02.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-02" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Marwin Gonz\u00e1lez.">
   <title>
    Marwin González Answer - September 02, 2025 | Name That Yankee
   </title>

--- a/2025-09-03.html
+++ b/2025-09-03.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-03" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Lance Berkman.">
   <title>
    Lance Berkman Answer - September 03, 2025 | Name That Yankee
   </title>

--- a/2025-09-03.html
+++ b/2025-09-03.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-03" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-03" rel="canonical"/><meta content="Discover the career highlights and statistics for Lance Berkman, the featured New York Yankee for the 2025-09-03 trivia puzzle." name="description"/>
+
+<title>
    Lance Berkman Answer - September 03, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 03, 2025: Lance Berkman. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 03, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-03.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 03, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-03.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 03, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 03, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-03.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-03"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 03, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Lance Berkman" src="images/answer-2025-09-03.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Lance Berkman" src="images/answer-2025-09-03.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Lance Berkman "Big Puma"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Named the 1997 National College Player of the Year after hitting 41 home runs with 134 RBI.
         </li>
-        <li>
+<li>
          Finished career with a 144 OPS+, tied for 38th all-time with Willie Mays and Mike Trout.
         </li>
-        <li>
+<li>
          Tied Game 6 of the 2011 World Series with a two-out, two-strike single in the 10th inning.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Lance Berkman?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Despite his elite peak performance, Lance Berkman's Hall of Fame case was short-lived. He received just 1.2% of the vote in his only year on the ballot in 2019, falling short of the 5% needed to remain eligible. While his rate stats like OPS+ are on par with inner-circle Hall of Famers, his counting stats (366 HR, 1,234 RBI) and a career shortened by injuries are often cited as reasons he was overlooked.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Despite his elite peak performance, Lance Berkman's Hall of Fame case was short-lived. He received just 1.2% of the vote in his only year on the ballot in 2019, falling short of the 5% needed to remain eligible. While his rate stats like OPS+ are on par with inner-circle Hall of Famers, his counting stats (366 HR, 1,234 RBI) and a career shortened by injuries are often cited as reasons he was overlooked.">
            Given his impressive career stats, how is Lance Berkman viewed in Hall of Fame discussions?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After joining the Yankees for their 2010 playoff push, Lance Berkman was a solid contributor in the ALCS against the Texas Rangers. Although the Yankees lost the series, he batted .320 with an .887 OPS in the six games. His performance included a solo home run off Colby Lewis in Game 3 at Yankee Stadium.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After joining the Yankees for their 2010 playoff push, Lance Berkman was a solid contributor in the ALCS against the Texas Rangers. Although the Yankees lost the series, he batted .320 with an .887 OPS in the six games. His performance included a solo home run off Colby Lewis in Game 3 at Yankee Stadium.">
            How did Lance Berkman perform for the Yankees in the 2010 postseason after being acquired at the trade deadline?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The nickname originated early in his career when a Houston reporter described the large-framed Berkman as a &quot;fat cat.&quot; Berkman playfully retorted, &quot;I'm more like a puma... sleek and agile.&quot; The name stuck, and he embraced the &quot;Big Puma&quot; moniker throughout his career, even having a puma logo stitched into his gloves.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The nickname originated early in his career when a Houston reporter described the large-framed Berkman as a &quot;fat cat.&quot; Berkman playfully retorted, &quot;I'm more like a puma... sleek and agile.&quot; The name stuck, and he embraced the &quot;Big Puma&quot; moniker throughout his career, even having a puma logo stitched into his gloves.">
            Where did Lance Berkman get his famous nickname, 'Big Puma'?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            52.0
           </td>
-          <td>
+<td>
            6491
           </td>
-          <td>
+<td>
            1905
           </td>
-          <td>
+<td>
            366
           </td>
-          <td>
+<td>
            .293
           </td>
-          <td>
+<td>
            1146
           </td>
-          <td>
+<td>
            1234
           </td>
-          <td>
+<td>
            86
           </td>
-          <td>
+<td>
            .406
           </td>
-          <td>
+<td>
            .537
           </td>
-          <td>
+<td>
            .943
           </td>
-          <td>
+<td>
            144
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-03.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013"];
             const warData = [0.2, 2.0, 6.5, 4.8, 5.3, 6.0, 3.2, 6.0, 2.2, 6.9, 3.5, 1.4, 3.8, 0.5, -0.1];
             const teamsByYear = ["HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "HOU", "2TM", "STL", "STL", "TEX"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["HOU", "TEX", "STL", "NYY"], "years": ["2013", "1999", "2002", "2006", "2008", "2009", "2001", "2007", "2003", "2000", "2011", "2004", "2010", "2012", "2005"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Lance Berkman", "hints": ["Named the 1997 National College Player of the Year after hitting 41 home runs with 134 RBI.", "Finished career with a 144 OPS+, tied for 38th all-time with Willie Mays and Mike Trout.", "Tied Game 6 of the 2011 World Series with a two-out, two-strike single in the 10th inning."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-04.html
+++ b/2025-09-04.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-04" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Jim Bouton, the featured New York Yankee for the 2025-09-04 trivia puzzle." name="description"/>
+
+<title>
    Jim Bouton Answer - September 04, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 04, 2025: Jim Bouton. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 04, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-04.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 04, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-04.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 04, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 04, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-04.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-04"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 04, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Jim Bouton" src="images/answer-2025-09-04.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jim Bouton" src="images/answer-2025-09-04.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Jim Bouton "Bulldog"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won two games in the 1964 World Series.
         </li>
-        <li>
+<li>
          Authored the 1970 baseball book 'Ball Four'.
         </li>
-        <li>
+<li>
          Returned to the major leagues in 1978 after a seven-year absence.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Jim Bouton?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Jim Bouton is remembered for both, but his book's impact arguably surpassed his pitching career. He was an All-Star pitcher for the Yankees, winning 21 games in 1963 and 18 in 1964. However, his 1970 book &quot;Ball Four&quot; was a groundbreaking exposé of players' lives that changed sports journalism and made him a controversial but hugely influential figure in baseball culture.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Jim Bouton is remembered for both, but his book's impact arguably surpassed his pitching career. He was an All-Star pitcher for the Yankees, winning 21 games in 1963 and 18 in 1964. However, his 1970 book &quot;Ball Four&quot; was a groundbreaking exposé of players' lives that changed sports journalism and made him a controversial but hugely influential figure in baseball culture.">
            How is Jim Bouton's career best remembered, as a successful pitcher or as the author of 'Ball Four'?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Pitching for the Yankees against the St. Louis Cardinals, Bouton was a standout performer in a losing effort. He threw a complete game in Game 3, allowing just one run in a 2-1 victory. He then came back on only two days' rest to win Game 6, securing an 8-3 victory to force a decisive seventh game.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Pitching for the Yankees against the St. Louis Cardinals, Bouton was a standout performer in a losing effort. He threw a complete game in Game 3, allowing just one run in a 2-1 victory. He then came back on only two days' rest to win Game 6, securing an 8-3 victory to force a decisive seventh game.">
            What were the details of Jim Bouton's two wins in the 1964 World Series?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="&quot;Ball Four&quot; shattered the idealized image of baseball players by revealing their off-field behavior, including heavy drinking, womanizing, and the widespread use of amphetamines. The book's candid, diary-style approach was condemned by the baseball establishment, and Commissioner Bowie Kuhn even tried to force Bouton to sign a statement saying the book was fictional. Many former teammates and players ostracized him for years for breaking the clubhouse's code of silence.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="&quot;Ball Four&quot; shattered the idealized image of baseball players by revealing their off-field behavior, including heavy drinking, womanizing, and the widespread use of amphetamines. The book's candid, diary-style approach was condemned by the baseball establishment, and Commissioner Bowie Kuhn even tried to force Bouton to sign a statement saying the book was fictional. Many former teammates and players ostracized him for years for breaking the clubhouse's code of silence.">
            Why was Jim Bouton's book 'Ball Four' so controversial when it was published?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            7.5
           </td>
-          <td>
+<td>
            62
           </td>
-          <td>
+<td>
            63
           </td>
-          <td>
+<td>
            3.57
           </td>
-          <td>
+<td>
            304
           </td>
-          <td>
+<td>
            144
           </td>
-          <td>
+<td>
            6
           </td>
-          <td>
+<td>
            1238.2
           </td>
-          <td>
+<td>
            720
           </td>
-          <td>
+<td>
            1.264
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-04.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1962", "1963", "1964", "1965", "1966", "1967", "1968", "1969", "1970", "1978"];
             const warData = [0.7, 4.8, 4.1, -0.8, 1.7, -0.8, -0.1, 0.6, -0.8, 0.0];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "HOU", "ATL"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SEP", "HOU", "NYY", "ATL"], "years": ["1964", "1963", "1965", "1968", "1978", "1970", "1962", "1967", "1966", "1969"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jim Bouton", "hints": ["Won two games in the 1964 World Series.", "Authored the 1970 baseball book 'Ball Four'.", "Returned to the major leagues in 1978 after a seven-year absence."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-04.html
+++ b/2025-09-04.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-04" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jim Bouton.">
   <title>
    Jim Bouton Answer - September 04, 2025 | Name That Yankee
   </title>

--- a/2025-09-05.html
+++ b/2025-09-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Alberto Castillo.">
   <title>
    Alberto Castillo Answer - September 05, 2025 | Name That Yankee
   </title>

--- a/2025-09-05.html
+++ b/2025-09-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Alberto Castillo, the featured New York Yankee for the 2025-09-05 trivia puzzle." name="description"/>
+
+<title>
    Alberto Castillo Answer - September 05, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 05, 2025: Alberto Castillo. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 05, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 05, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 05, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 05, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 05, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Alberto Castillo" src="images/answer-2025-09-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Alberto Castillo" src="images/answer-2025-09-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Alberto Castillo
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Played in the 2000 World Series with the New York Mets.
         </li>
-        <li>
+<li>
          Caught the final out of the 2000 National League Championship Series.
         </li>
-        <li>
+<li>
          Finished a 12-year MLB career with a 36% caught stealing percentage.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Alberto Castillo?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Alberto Castillo was highly regarded for his defensive skills and ability to handle a pitching staff. Over 12 seasons with seven different teams, he established himself as a reliable backup, prized more for his glove than his bat. His career 36% caught stealing percentage was significantly better than the league average during his era, cementing his reputation as a premier defensive catcher.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Alberto Castillo was highly regarded for his defensive skills and ability to handle a pitching staff. Over 12 seasons with seven different teams, he established himself as a reliable backup, prized more for his glove than his bat. His career 36% caught stealing percentage was significantly better than the league average during his era, cementing his reputation as a premier defensive catcher.">
            Besides his strong arm, what defined Alberto Castillo's long career as a backup catcher?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Serving as the backup to Jorge Posada in 2002, Alberto Castillo's most notable offensive contribution came on May 12 against the Minnesota Twins. He hit a three-run home run off pitcher Brad Radke, which accounted for the majority of the team's offense in a game the Yankees would eventually win 4-3.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Serving as the backup to Jorge Posada in 2002, Alberto Castillo's most notable offensive contribution came on May 12 against the Minnesota Twins. He hit a three-run home run off pitcher Brad Radke, which accounted for the majority of the team's offense in a game the Yankees would eventually win 4-3.">
            What was Alberto Castillo's most significant contribution during his one season with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, Alberto Castillo was known for his highly unconventional and extremely open batting stance. He would set up almost facing the pitcher, with his front foot pointed far toward the third-base dugout, before taking a long stride toward the plate as the pitch was delivered. This unique approach made him one of the more distinctive hitters of his time.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, Alberto Castillo was known for his highly unconventional and extremely open batting stance. He would set up almost facing the pitcher, with his front foot pointed far toward the third-base dugout, before taking a long stride toward the plate as the pitch was delivered. This unique approach made him one of the more distinctive hitters of his time.">
            Was there anything unusual about Alberto Castillo's style at the plate?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.7
           </td>
-          <td>
+<td>
            1026
           </td>
-          <td>
+<td>
            226
           </td>
-          <td>
+<td>
            12
           </td>
-          <td>
+<td>
            .220
           </td>
-          <td>
+<td>
            98
           </td>
-          <td>
+<td>
            101
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            .293
           </td>
-          <td>
+<td>
            .297
           </td>
-          <td>
+<td>
            .590
           </td>
-          <td>
+<td>
            54
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2007"];
             const warData = [0.1, 0.0, -0.1, 0.6, 0.8, -0.1, -0.2, -0.4, 0.0, 0.7, 0.4, -0.1];
             const teamsByYear = ["NYM", "NYM", "NYM", "NYM", "STL", "TOR", "TOR", "NYY", "SFG", "KCR", "2TM", "BAL"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYM", "NYY", "TOR", "BAL", "OAK", "STL", "KCR", "SFG"], "years": ["2003", "2002", "2001", "2005", "2000", "1997", "2007", "1999", "1996", "1995", "1998", "2004"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Alberto Castillo", "hints": ["Played in the 2000 World Series with the New York Mets.", "Caught the final out of the 2000 National League Championship Series.", "Finished a 12-year MLB career with a 36% caught stealing percentage."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-06.html
+++ b/2025-09-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Bob MacDonald, the featured New York Yankee for the 2025-09-06 trivia puzzle." name="description"/>
+
+<title>
    Bob MacDonald Answer - September 06, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 06, 2025: Bob MacDonald. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 06, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 06, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 06, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 06, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 06, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bob MacDonald" src="images/answer-2025-09-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bob MacDonald" src="images/answer-2025-09-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bob MacDonald
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched for the Seattle Pilots and Toronto Blue Jays in their inaugural seasons.
         </li>
-        <li>
+<li>
          Had an eight-year gap between major league appearances from 1969 to 1977.
         </li>
-        <li>
+<li>
          Was a member of the Seattle Pilots during the team's only season of existence.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Bob MacDonald?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Bob MacDonald holds the rare distinction of pitching for two different franchises in their inaugural seasons: the 1969 Seattle Pilots and the 1977 Toronto Blue Jays. He is one of only two players to do so, along with Diego Segui. His career is also notable for the seven full seasons he spent in the minor leagues between his major league appearances in 1969 and 1977.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Bob MacDonald holds the rare distinction of pitching for two different franchises in their inaugural seasons: the 1969 Seattle Pilots and the 1977 Toronto Blue Jays. He is one of only two players to do so, along with Diego Segui. His career is also notable for the seven full seasons he spent in the minor leagues between his major league appearances in 1969 and 1977.">
            What makes Bob MacDonald's career so unique, particularly his connection to two inaugural MLB teams?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Bob MacDonald never played for the New York Yankees. His entire three-season major league career was spent with the American League's two expansion franchises of that era, the Seattle Pilots and the Toronto Blue Jays.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Bob MacDonald never played for the New York Yankees. His entire three-season major league career was spent with the American League's two expansion franchises of that era, the Seattle Pilots and the Toronto Blue Jays.">
            What was Bob MacDonald's most memorable moment as a member of the New York Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After his playing days were over, Bob MacDonald returned to his hometown of East Orange, New Jersey, to become a teacher and coach. He taught physical education and health at his alma mater, East Orange High School. He also coached the school's baseball and basketball teams for many years.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After his playing days were over, Bob MacDonald returned to his hometown of East Orange, New Jersey, to become a teacher and coach. He taught physical education and health at his alma mater, East Orange High School. He also coached the school's baseball and basketball teams for many years.">
            What did Bob MacDonald do after his professional baseball career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.2
           </td>
-          <td>
+<td>
            8
           </td>
-          <td>
+<td>
            9
           </td>
-          <td>
+<td>
            4.34
           </td>
-          <td>
+<td>
            197
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            234.1
           </td>
-          <td>
+<td>
            142
           </td>
-          <td>
+<td>
            1.455
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1990", "1991", "1992", "1993", "1995", "1996"];
             const warData = [0.2, 1.0, 0.1, -0.4, 0.3, -0.1];
             const teamsByYear = ["TOR", "TOR", "TOR", "DET", "NYY", "NYM"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["DET", "NYM", "TOR", "NYY"], "years": ["1992", "1990", "1993", "1996", "1995", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bob MacDonald", "hints": ["Pitched for the Seattle Pilots and Toronto Blue Jays in their inaugural seasons.", "Had an eight-year gap between major league appearances from 1969 to 1977.", "Was a member of the Seattle Pilots during the team's only season of existence."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-06.html
+++ b/2025-09-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bob MacDonald.">
   <title>
    Bob MacDonald Answer - September 06, 2025 | Name That Yankee
   </title>

--- a/2025-09-07.html
+++ b/2025-09-07.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-07" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-07" rel="canonical"/><meta content="Discover the career highlights and statistics for Don Mattingly, the featured New York Yankee for the 2025-09-07 trivia puzzle." name="description"/>
+
+<title>
    Don Mattingly Answer - September 07, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 07, 2025: Don Mattingly. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 07, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-07.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 07, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-07.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 07, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-07.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 07, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-07.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-07"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 07, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Don Mattingly" src="images/answer-2025-09-07.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Don Mattingly" src="images/answer-2025-09-07.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Don Mattingly "Donnie Baseball"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Hit a single-season record six grand slams in 1987.
         </li>
-        <li>
+<li>
          Tied the major league record by hitting a home run in eight consecutive games.
         </li>
-        <li>
+<li>
          Won nine Gold Glove Awards at first base.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Don Mattingly?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer='Don Mattingly is often seen as one of the best players not in the Hall of Fame, a victim of a career shortened by chronic back injuries. From 1984 to 1989, he won an MVP, a batting title, three Silver Sluggers, and five Gold Gloves, establishing himself as a superstar. However, his power numbers declined significantly afterward, and his career totals fall short of typical Hall of Fame standards, creating a classic "peak vs. longevity" debate among voters.'>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer='Don Mattingly is often seen as one of the best players not in the Hall of Fame, a victim of a career shortened by chronic back injuries. From 1984 to 1989, he won an MVP, a batting title, three Silver Sluggers, and five Gold Gloves, establishing himself as a superstar. However, his power numbers declined significantly afterward, and his career totals fall short of typical Hall of Fame standards, creating a classic "peak vs. longevity" debate among voters.'>
            With such a dominant peak in the mid-1980s, how is Don Mattingly's overall career and Hall of Fame case generally viewed?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In 1987, Don Mattingly hit six grand slams, a single-season MLB record that still stands (tied by Travis Hafner in 2006). Remarkably, these were the only six grand slams of his entire 14-year career. The record-setting sixth blast came on September 29, 1987, against the Boston Red Sox at Yankee Stadium.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In 1987, Don Mattingly hit six grand slams, a single-season MLB record that still stands (tied by Travis Hafner in 2006). Remarkably, these were the only six grand slams of his entire 14-year career. The record-setting sixth blast came on September 29, 1987, against the Boston Red Sox at Yankee Stadium.">
            What was the story behind Don Mattingly's record-setting six grand slams in a single season?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In 1991, Mattingly was famously benched and fined $250 for refusing to cut his mullet, which violated owner George Steinbrenner's strict team grooming policy. The standoff became a major media story, symbolizing the clash between player individuality and the team's buttoned-up corporate image. The incident was later parodied in the classic &quot;Simpsons&quot; episode &quot;Homer at the Bat,&quot; where Mr. Burns repeatedly demands Mattingly shave his sideburns.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In 1991, Mattingly was famously benched and fined $250 for refusing to cut his mullet, which violated owner George Steinbrenner's strict team grooming policy. The standoff became a major media story, symbolizing the clash between player individuality and the team's buttoned-up corporate image. The incident was later parodied in the classic &quot;Simpsons&quot; episode &quot;Homer at the Bat,&quot; where Mr. Burns repeatedly demands Mattingly shave his sideburns.">
            What was the famous off-field issue Don Mattingly had with Yankees management regarding his appearance?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            42.4
           </td>
-          <td>
+<td>
            7003
           </td>
-          <td>
+<td>
            2153
           </td>
-          <td>
+<td>
            222
           </td>
-          <td>
+<td>
            .307
           </td>
-          <td>
+<td>
            1007
           </td>
-          <td>
+<td>
            1099
           </td>
-          <td>
+<td>
            14
           </td>
-          <td>
+<td>
            .358
           </td>
-          <td>
+<td>
            .471
           </td>
-          <td>
+<td>
            .830
           </td>
-          <td>
+<td>
            127
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-07.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-07.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995"];
             const warData = [-0.1, 0.5, 6.3, 6.4, 7.2, 5.1, 3.7, 4.2, -0.3, 1.7, 2.8, 2.7, 2.3, -0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY"], "years": ["1986", "1984", "1990", "1995", "1988", "1987", "1983", "1985", "1993", "1989", "1994", "1991", "1982", "1992"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Don Mattingly", "nickname": "Donnie Baseball", "hints": ["Hit a single-season record six grand slams in 1987.", "Tied the major league record by hitting a home run in eight consecutive games.", "Won nine Gold Glove Awards at first base."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-07.html
+++ b/2025-09-07.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-07" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Don Mattingly.">
   <title>
    Don Mattingly Answer - September 07, 2025 | Name That Yankee
   </title>

--- a/2025-09-09.html
+++ b/2025-09-09.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-09" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Joba Chamberlain.">
   <title>
    Joba Chamberlain Answer - September 09, 2025 | Name That Yankee
   </title>

--- a/2025-09-09.html
+++ b/2025-09-09.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-09" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-09" rel="canonical"/><meta content="Discover the career highlights and statistics for Joba Chamberlain, the featured New York Yankee for the 2025-09-09 trivia puzzle." name="description"/>
+
+<title>
    Joba Chamberlain Answer - September 09, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 09, 2025: Joba Chamberlain. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 09, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-09.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 09, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-09.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 09, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-09.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 09, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-09.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-09"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 09, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Joba Chamberlain" src="images/answer-2025-09-09.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Joba Chamberlain" src="images/answer-2025-09-09.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Joba Chamberlain "Joba"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was the subject of specific workload restrictions created by the New York Yankees known as the 'Joba Rules'.
         </li>
-        <li>
+<li>
          Posted a 0.38 ERA over the first 19 appearances of a major league career.
         </li>
-        <li>
+<li>
          Won a World Series with the New York Yankees in 2009.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Joba Chamberlain?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Joba Chamberlain's career was defined by an electric debut as a high-leverage reliever, followed by a difficult and injury-plagued transition to the starting rotation. The much-debated 'Joba Rules' were implemented to manage his workload, but Tommy John surgery and a severe open dislocation of his ankle ultimately limited his effectiveness. After leaving the Yankees, he pitched as a middle reliever for several other teams before his career ended.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Joba Chamberlain's career was defined by an electric debut as a high-leverage reliever, followed by a difficult and injury-plagued transition to the starting rotation. The much-debated 'Joba Rules' were implemented to manage his workload, but Tommy John surgery and a severe open dislocation of his ankle ultimately limited his effectiveness. After leaving the Yankees, he pitched as a middle reliever for several other teams before his career ended.">
            Despite his dominant start, what defined Joba Chamberlain's overall career trajectory?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In Game 2 of the 2007 ALDS against Cleveland, a massive swarm of midges descended upon the field in the 8th inning with the Yankees leading 1-0. The insects visibly bothered Chamberlain on the mound, affecting his command as he threw two wild pitches that allowed the tying run to score. The Yankees went on to lose the game and, eventually, the series, with the 'bug game' becoming an infamous moment in franchise playoff history.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In Game 2 of the 2007 ALDS against Cleveland, a massive swarm of midges descended upon the field in the 8th inning with the Yankees leading 1-0. The insects visibly bothered Chamberlain on the mound, affecting his command as he threw two wild pitches that allowed the tying run to score. The Yankees went on to lose the game and, eventually, the series, with the 'bug game' becoming an infamous moment in franchise playoff history.">
            What was the story behind Joba Chamberlain and the midges during the 2007 playoffs?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Joba is a portmanteau of the first names of his father, Harlan, and his father's cousin, who were named after John F. Kennedy and his brother Robert F. Kennedy. His father's name was originally John, but he went by Joba, a name he passed on to his son. The full name on his birth certificate is Justin Louis Chamberlain.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Joba is a portmanteau of the first names of his father, Harlan, and his father's cousin, who were named after John F. Kennedy and his brother Robert F. Kennedy. His father's name was originally John, but he went by Joba, a name he passed on to his son. The full name on his birth certificate is Justin Louis Chamberlain.">
            How did Joba Chamberlain get his distinctive first name?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            7.6
           </td>
-          <td>
+<td>
            25
           </td>
-          <td>
+<td>
            21
           </td>
-          <td>
+<td>
            3.81
           </td>
-          <td>
+<td>
            385
           </td>
-          <td>
+<td>
            43
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            555.1
           </td>
-          <td>
+<td>
            546
           </td>
-          <td>
+<td>
            1.379
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-09.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-09.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015", "2016"];
             const warData = [1.4, 3.5, 1.4, 0.1, 0.7, 0.0, -0.1, 0.9, -0.6, 0.4];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "DET", "2TM", "CLE"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["DET", "CLE", "NYY", "KCR"], "years": ["2016", "2011", "2008", "2009", "2010", "2012", "2013", "2007", "2014", "2015"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Joba Chamberlain", "hints": ["Was the subject of specific workload restrictions created by the New York Yankees known as the 'Joba Rules'.", "Posted a 0.38 ERA over the first 19 appearances of a major league career.", "Won a World Series with the New York Yankees in 2009."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-10.html
+++ b/2025-09-10.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-10" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Cecil Fielder, the featured New York Yankee for the 2025-09-10 trivia puzzle." name="description"/>
+
+<title>
    Cecil Fielder Answer - September 10, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 10, 2025: Cecil Fielder. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 10, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-10.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 10, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-10.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 10, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 10, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-10.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-10"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 10, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Cecil Fielder" src="images/answer-2025-09-10.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Cecil Fielder" src="images/answer-2025-09-10.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Cecil Fielder "Big Daddy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Became the first American League player to hit 50 home runs in a season since 1961.
         </li>
-        <li>
+<li>
          Part of the only father-son duo in MLB history to each hit 50 home runs in a season.
         </li>
-        <li>
+<li>
          Led the American League in RBIs for three consecutive seasons from 1990-1992.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Cecil Fielder?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Fielder began with the Toronto Blue Jays but first became a star in Japan, hitting 38 home runs for the Hanshin Tigers in 1989. This led to his dominant run with the Detroit Tigers, where he became one of baseball's most feared sluggers. He finished his career as a key designated hitter and first baseman, most notably winning a World Series with the New York Yankees in 1996.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Fielder began with the Toronto Blue Jays but first became a star in Japan, hitting 38 home runs for the Hanshin Tigers in 1989. This led to his dominant run with the Detroit Tigers, where he became one of baseball's most feared sluggers. He finished his career as a key designated hitter and first baseman, most notably winning a World Series with the New York Yankees in 1996.">
            Besides his incredible power surge with the Tigers, what was the overall shape of Cecil Fielder's career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Acquired by the Yankees in a July 1996 trade, Fielder provided immediate and crucial power to the middle of the lineup. He hit 13 home runs in just 53 regular-season games for New York. During the 1996 postseason, he drove in 14 runs and hit three home runs, including one in the World Series, helping the Yankees capture their first title since 1978.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Acquired by the Yankees in a July 1996 trade, Fielder provided immediate and crucial power to the middle of the lineup. He hit 13 home runs in just 53 regular-season games for New York. During the 1996 postseason, he drove in 14 runs and hit three home runs, including one in the World Series, helping the Yankees capture their first title since 1978.">
            What role did Cecil Fielder play in the Yankees' 1996 World Series championship?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The nickname &quot;Big Daddy&quot; was a natural fit due to Fielder's large physical stature and his prodigious power at the plate. It became widely used by teammates, media, and fans during his dominant years with the Detroit Tigers. The name perfectly captured his imposing presence in the batter's box.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The nickname &quot;Big Daddy&quot; was a natural fit due to Fielder's large physical stature and his prodigious power at the plate. It became widely used by teammates, media, and fans during his dominant years with the Detroit Tigers. The name perfectly captured his imposing presence in the batter's box.">
            Where did Cecil Fielder get his famous 'Big Daddy' nickname?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            17.2
           </td>
-          <td>
+<td>
            5157
           </td>
-          <td>
+<td>
            1313
           </td>
-          <td>
+<td>
            319
           </td>
-          <td>
+<td>
            .255
           </td>
-          <td>
+<td>
            744
           </td>
-          <td>
+<td>
            1008
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            .345
           </td>
-          <td>
+<td>
            .482
           </td>
-          <td>
+<td>
            .827
           </td>
-          <td>
+<td>
            119
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-10.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1985", "1986", "1987", "1988", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998"];
             const warData = [0.8, -0.7, 0.4, -0.3, 6.5, 3.8, 2.8, 0.6, 1.9, 0.6, 0.9, 0.8, -0.9];
             const teamsByYear = ["TOR", "TOR", "TOR", "TOR", "DET", "DET", "DET", "DET", "DET", "DET", "2TM", "NYY", "2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TOR", "DET", "ANA", "CLE", "NYY"], "years": ["1986", "1998", "1997", "1995", "1990", "1996", "1988", "1987", "1985", "1993", "1994", "1991", "1992"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Cecil Fielder", "hints": ["Became the first American League player to hit 50 home runs in a season since 1961.", "Part of the only father-son duo in MLB history to each hit 50 home runs in a season.", "Led the American League in RBIs for three consecutive seasons from 1990-1992."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-10.html
+++ b/2025-09-10.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-10" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Cecil Fielder.">
   <title>
    Cecil Fielder Answer - September 10, 2025 | Name That Yankee
   </title>

--- a/2025-09-13.html
+++ b/2025-09-13.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-13" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-13" rel="canonical"/><meta content="Discover the career highlights and statistics for Bill Monbouquette, the featured New York Yankee for the 2025-09-13 trivia puzzle." name="description"/>
+
+<title>
    Bill Monbouquette Answer - September 13, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 13, 2025: Bill Monbouquette. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 13, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-13.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 13, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-13.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 13, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 13, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-13.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-13"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 13, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bill Monbouquette" src="images/answer-2025-09-13.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bill Monbouquette" src="images/answer-2025-09-13.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bill Monbouquette "Monbo"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Pitched a no-hitter against the Chicago White Sox on August 1, 1962.
         </li>
-        <li>
+<li>
          Struck out 17 batters in a single game on May 12, 1961.
         </li>
-        <li>
+<li>
          Was selected to four American League All-Star teams.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Bill Monbouquette?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Bill Monbouquette was the workhorse ace for some largely forgettable Boston Red Sox teams in the early 1960s. He led the team in wins three times and was known for his durability and competitive fire on the mound. Despite the team's lack of success, he was consistently one of the top pitchers in the American League during his peak.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Bill Monbouquette was the workhorse ace for some largely forgettable Boston Red Sox teams in the early 1960s. He led the team in wins three times and was known for his durability and competitive fire on the mound. Despite the team's lack of success, he was consistently one of the top pitchers in the American League during his peak.">
            Considering his All-Star selections and no-hitter, what was Bill Monbouquette's overall reputation as a pitcher for the Red Sox?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Monbouquette joined the Yankees for the 1967 and 1968 seasons, after his prime years with Boston. He served as a veteran arm for a team in a rebuilding phase, working as both a spot starter and a reliever. In his two seasons in pinstripes, he posted a combined 6-8 record with a 3.20 ERA in 46 appearances.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Monbouquette joined the Yankees for the 1967 and 1968 seasons, after his prime years with Boston. He served as a veteran arm for a team in a rebuilding phase, working as both a spot starter and a reliever. In his two seasons in pinstripes, he posted a combined 6-8 record with a 3.20 ERA in 46 appearances.">
            What was Bill Monbouquette's role with the Yankees toward the end of his career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, he enjoyed a long and respected second career as a pitching coach that spanned several decades. He served as a major league coach for the New York Mets, New York Yankees, and Toronto Blue Jays. He was also a minor league instructor for multiple organizations, where he was highly regarded for his ability to mentor young pitchers.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, he enjoyed a long and respected second career as a pitching coach that spanned several decades. He served as a major league coach for the New York Mets, New York Yankees, and Toronto Blue Jays. He was also a minor league instructor for multiple organizations, where he was highly regarded for his ability to mentor young pitchers.">
            Did Bill Monbouquette stay involved in baseball after he stopped playing?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            20.8
           </td>
-          <td>
+<td>
            114
           </td>
-          <td>
+<td>
            112
           </td>
-          <td>
+<td>
            3.68
           </td>
-          <td>
+<td>
            343
           </td>
-          <td>
+<td>
            263
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            1961.1
           </td>
-          <td>
+<td>
            1122
           </td>
-          <td>
+<td>
            1.253
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-13.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1958", "1959", "1960", "1961", "1962", "1963", "1964", "1965", "1966", "1967", "1968"];
             const warData = [0.4, 0.1, 4.9, 3.9, 3.8, 2.9, 2.9, 2.2, -0.8, 3.4, -1.1];
             const teamsByYear = ["BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "BOS", "DET", "2TM", "2TM"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["DET", "BOS", "SFG", "NYY"], "years": ["1958", "1963", "1960", "1961", "1959", "1965", "1966", "1962", "1968", "1964", "1967"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bill Monbouquette", "hints": ["Pitched a no-hitter against the Chicago White Sox on August 1, 1962.", "Struck out 17 batters in a single game on May 12, 1961.", "Was selected to four American League All-Star teams."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-13.html
+++ b/2025-09-13.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-13" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bill Monbouquette.">
   <title>
    Bill Monbouquette Answer - September 13, 2025 | Name That Yankee
   </title>

--- a/2025-09-15.html
+++ b/2025-09-15.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-15" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Roy Smalley III.">
   <title>
    Roy Smalley III Answer - September 15, 2025 | Name That Yankee
   </title>

--- a/2025-09-15.html
+++ b/2025-09-15.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-15" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-15" rel="canonical"/><meta content="Discover the career highlights and statistics for Roy Smalley III, the featured New York Yankee for the 2025-09-15 trivia puzzle." name="description"/>
+
+<title>
    Roy Smalley III Answer - September 15, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 15, 2025: Roy Smalley III. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 15, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-15.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 15, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-15.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 15, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-15.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 15, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-15.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-15"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 15, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Roy Smalley III" src="images/answer-2025-09-15.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Roy Smalley III" src="images/answer-2025-09-15.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Roy Smalley III
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Father was a major league shortstop for 11 seasons.
         </li>
-        <li>
+<li>
          Uncle was major league player and manager Gene Mauch.
         </li>
-        <li>
+<li>
          Was an American League All-Star in 1979.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Roy Smalley III?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Roy Smalley was a durable, switch-hitting shortstop who provided solid power from a premium defensive position. In his 1979 All-Star season, he hit 24 home runs and led all American League shortstops in games played, assists, and double plays turned. He followed that by leading the AL with 146 games at shortstop in 1980, cementing his reputation as a reliable everyday player.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Roy Smalley was a durable, switch-hitting shortstop who provided solid power from a premium defensive position. In his 1979 All-Star season, he hit 24 home runs and led all American League shortstops in games played, assists, and double plays turned. He followed that by leading the AL with 146 games at shortstop in 1980, cementing his reputation as a reliable everyday player.">
            Besides his All-Star season, what defined Roy Smalley's peak years as the starting shortstop for the Minnesota Twins?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Acquired from the Twins in an April 1982 trade, Smalley had a productive first season in New York, hitting a career-high 26 home runs and driving in 82 runs. He primarily played shortstop but also saw significant time at third base. His power numbers were a key contribution to a Yankees team that finished second in the AL East that year.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Acquired from the Twins in an April 1982 trade, Smalley had a productive first season in New York, hitting a career-high 26 home runs and driving in 82 runs. He primarily played shortstop but also saw significant time at third base. His power numbers were a key contribution to a Yankees team that finished second in the AL East that year.">
            How did Roy Smalley perform after being traded to the New York Yankees in 1982?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring as a player, Roy Smalley became a well-regarded television analyst for the Minnesota Twins on various networks for nearly two decades. He also served as an executive vice president for the Major League Baseball Players Alumni Association. His post-playing career kept him closely connected to the game and the Twins organization.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring as a player, Roy Smalley became a well-regarded television analyst for the Minnesota Twins on various networks for nearly two decades. He also served as an executive vice president for the Major League Baseball Players Alumni Association. His post-playing career kept him closely connected to the game and the Twins organization.">
            What did Roy Smalley do after his playing career ended?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            27.9
           </td>
-          <td>
+<td>
            5657
           </td>
-          <td>
+<td>
            1454
           </td>
-          <td>
+<td>
            163
           </td>
-          <td>
+<td>
            .257
           </td>
-          <td>
+<td>
            745
           </td>
-          <td>
+<td>
            694
           </td>
-          <td>
+<td>
            27
           </td>
-          <td>
+<td>
            .345
           </td>
-          <td>
+<td>
            .395
           </td>
-          <td>
+<td>
            .740
           </td>
-          <td>
+<td>
            103
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-15.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-15.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987"];
             const warData = [1.1, 3.0, 1.6, 5.9, 4.3, 3.4, 0.6, 2.9, 2.9, 0.2, 1.0, 0.9, 0.2];
             const teamsByYear = ["TEX", "2TM", "MIN", "MIN", "MIN", "MIN", "MIN", "2TM", "NYY", "2TM", "MIN", "MIN", "MIN"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW", "TEX", "MIN"], "years": ["1986", "1984", "1979", "1977", "1987", "1978", "1975", "1981", "1983", "1985", "1976", "1980", "1982"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Roy Smalley III", "hints": ["Father was a major league shortstop for 11 seasons.", "Uncle was major league player and manager Gene Mauch.", "Was an American League All-Star in 1979."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-16.html
+++ b/2025-09-16.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-16" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ron Davis.">
   <title>
    Ron Davis Answer - September 16, 2025 | Name That Yankee
   </title>

--- a/2025-09-16.html
+++ b/2025-09-16.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-16" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-16" rel="canonical"/><meta content="Discover the career highlights and statistics for Ron Davis, the featured New York Yankee for the 2025-09-16 trivia puzzle." name="description"/>
+
+<title>
    Ron Davis Answer - September 16, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 16, 2025: Ron Davis. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 16, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-16.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 16, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-16.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 16, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-16.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 16, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-16.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-16"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 16, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Ron Davis" src="images/answer-2025-09-16.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ron Davis" src="images/answer-2025-09-16.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Ron Davis "The Vulture"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Was an American League All-Star in 1981.
         </li>
-        <li>
+<li>
          Set an American League record by striking out eight consecutive batters in a single game.
         </li>
-        <li>
+<li>
          Father of former MLB first baseman Ike Davis.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Ron Davis?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Ron Davis was a formidable setup man for the Yankees, primarily known for his overpowering fastball. He formed a devastating late-inning bullpen duo with closer Goose Gossage, earning an All-Star selection in 1981. After being traded to the Minnesota Twins, he became their closer and saved 20 or more games in three consecutive seasons.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Ron Davis was a formidable setup man for the Yankees, primarily known for his overpowering fastball. He formed a devastating late-inning bullpen duo with closer Goose Gossage, earning an All-Star selection in 1981. After being traded to the Minnesota Twins, he became their closer and saved 20 or more games in three consecutive seasons.">
            Beyond his strikeout record, what defined Ron Davis's career as a dominant relief pitcher?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="On May 4, 1981, in a game against the California Angels, Ron Davis entered in relief and was untouchable. He struck out eight consecutive batters, a feat that included striking out the side in both the eighth and ninth innings. This record-setting performance helped secure a 4-2 Yankees victory in extra innings.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="On May 4, 1981, in a game against the California Angels, Ron Davis entered in relief and was untouchable. He struck out eight consecutive batters, a feat that included striking out the side in both the eighth and ninth innings. This record-setting performance helped secure a 4-2 Yankees victory in extra innings.">
            What were the details of the game where Ron Davis set the American League record for consecutive strikeouts as a Yankee?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Ron Davis was deeply involved in his son's baseball development, serving as a coach and mentor from a young age. When Ike became a first baseman for the New York Mets, Ron was a frequent and supportive presence at his games. This created a unique New York baseball dynamic, with the former Yankee star passionately cheering for his son on the cross-town rival team.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Ron Davis was deeply involved in his son's baseball development, serving as a coach and mentor from a young age. When Ike became a first baseman for the New York Mets, Ron was a frequent and supportive presence at his games. This created a unique New York baseball dynamic, with the former Yankee star passionately cheering for his son on the cross-town rival team.">
            How involved was Ron Davis in the baseball career of his son, Ike Davis?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            4.8
           </td>
-          <td>
+<td>
            47
           </td>
-          <td>
+<td>
            53
           </td>
-          <td>
+<td>
            4.05
           </td>
-          <td>
+<td>
            481
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            130
           </td>
-          <td>
+<td>
            746.2
           </td>
-          <td>
+<td>
            597
           </td>
-          <td>
+<td>
            1.386
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-16.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-16.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988"];
             const warData = [-0.2, 2.2, 2.3, 1.6, 0.1, 2.0, -0.9, 1.0, -2.7, -0.3, -0.1];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "MIN", "MIN", "MIN", "MIN", "2TM", "2TM", "SFG"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["SFG", "LAD", "MIN", "CHC", "NYY"], "years": ["1986", "1984", "1988", "1979", "1987", "1978", "1981", "1983", "1985", "1980", "1982"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Ron Davis", "hints": ["Was an American League All-Star in 1981.", "Set an American League record by striking out eight consecutive batters in a single game.", "Father of former MLB first baseman Ike Davis."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-17.html
+++ b/2025-09-17.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-17" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Vernon Gomez.">
   <title>
    Vernon Gomez Answer - September 17, 2025 | Name That Yankee
   </title>

--- a/2025-09-17.html
+++ b/2025-09-17.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-17" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-17" rel="canonical"/><meta content="Discover the career highlights and statistics for Vernon Gomez, the featured New York Yankee for the 2025-09-17 trivia puzzle." name="description"/>
+
+<title>
    Vernon Gomez Answer - September 17, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 17, 2025: Vernon Gomez. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 17, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-17.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 17, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-17.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 17, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-17.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 17, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-17.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-17"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 17, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Vernon Gomez" src="images/answer-2025-09-17.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Vernon Gomez" src="images/answer-2025-09-17.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Vernon Gomez "Lefty"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the American League pitching Triple Crown in both 1934 and 1937.
         </li>
-        <li>
+<li>
          Posted a 6-0 record across five different World Series.
         </li>
-        <li>
+<li>
          Was the winning pitcher in the first-ever Major League Baseball All-Star Game in 1933.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Vernon Gomez?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Vernon &quot;Lefty&quot; Gomez was the ace of the powerful Yankees teams of that era, winning the American League pitching Triple Crown twice, in 1934 and 1937. He led the league in wins and strikeouts three times each and posted four 20-win seasons. This sustained excellence was a key reason for the Yankees' five World Series championships during his tenure and led to his Hall of Fame induction in 1972.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Vernon &quot;Lefty&quot; Gomez was the ace of the powerful Yankees teams of that era, winning the American League pitching Triple Crown twice, in 1934 and 1937. He led the league in wins and strikeouts three times each and posted four 20-win seasons. This sustained excellence was a key reason for the Yankees' five World Series championships during his tenure and led to his Hall of Fame induction in 1972.">
            What made Vernon Gomez one of the most dominant pitchers of the 1930s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Gomez was flawless in the postseason, posting a perfect 6-0 record in World Series play, which remains the record for most wins without a loss. Across five Fall Classics for the Yankees, he maintained a 2.86 ERA. He was the winning pitcher in the clinching game of the 1937 World Series against the New York Giants.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Gomez was flawless in the postseason, posting a perfect 6-0 record in World Series play, which remains the record for most wins without a loss. Across five Fall Classics for the Yankees, he maintained a 2.86 ERA. He was the winning pitcher in the clinching game of the 1937 World Series against the New York Giants.">
            How dominant was Vernon Gomez in the World Series for the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, Gomez was famous for his sharp wit and self-deprecating humor, making him one of baseball's most renowned characters. He is credited with many classic quotes, including his explanation for his success: &quot;The secret of my success is clean living and a fast outfield.&quot; He also famously quipped, &quot;I'd rather be lucky than good.&quot;">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, Gomez was famous for his sharp wit and self-deprecating humor, making him one of baseball's most renowned characters. He is credited with many classic quotes, including his explanation for his success: &quot;The secret of my success is clean living and a fast outfield.&quot; He also famously quipped, &quot;I'd rather be lucky than good.&quot;">
            Was Vernon Gomez known for having a particularly colorful personality?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            38.7
           </td>
-          <td>
+<td>
            189
           </td>
-          <td>
+<td>
            102
           </td>
-          <td>
+<td>
            3.34
           </td>
-          <td>
+<td>
            368
           </td>
-          <td>
+<td>
            320
           </td>
-          <td>
+<td>
            10
           </td>
-          <td>
+<td>
            2503.0
           </td>
-          <td>
+<td>
            1468
           </td>
-          <td>
+<td>
            1.352
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-17.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-17.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1930", "1931", "1932", "1933", "1934", "1935", "1936", "1937", "1938", "1939", "1940", "1941", "1942", "1943"];
             const warData = [-0.1, 5.9, 3.4, 3.7, 8.4, 4.1, 1.5, 9.2, 4.6, 3.0, -0.5, 1.0, -0.7, -0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "WSH"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["WSH", "NYY"], "years": ["1941", "1939", "1938", "1931", "1937", "1935", "1933", "1936", "1932", "1943", "1934", "1930", "1940", "1942"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Vernon Gomez", "hints": ["Won the American League pitching Triple Crown in both 1934 and 1937.", "Posted a 6-0 record across five different World Series.", "Was the winning pitcher in the first-ever Major League Baseball All-Star Game in 1933."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-19.html
+++ b/2025-09-19.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul Blair, the featured New York Yankee for the 2025-09-19 trivia puzzle." name="description"/>
+
+<title>
    Paul Blair Answer - September 19, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 19, 2025: Paul Blair. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 19, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 19, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-19.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 19, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 19, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-19.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-19"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 19, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul Blair" src="images/answer-2025-09-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul Blair" src="images/answer-2025-09-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul Blair "Motormouth"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won eight Gold Glove Awards as an outfielder.
         </li>
-        <li>
+<li>
          Won four World Series championships with the Orioles and Yankees.
         </li>
-        <li>
+<li>
          Batted .474 with nine hits in the 1970 World Series.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Paul Blair?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Paul Blair was famous for playing an unusually shallow center field, relying on his extraordinary speed and instincts to get a great jump on the ball. His ability to go back on deep drives was legendary, and Hall of Fame teammate Brooks Robinson called him the best defensive outfielder he ever saw. Blair's defensive prowess was so respected that the term &quot;No-Fly Zone&quot; was often used to describe his territory.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Paul Blair was famous for playing an unusually shallow center field, relying on his extraordinary speed and instincts to get a great jump on the ball. His ability to go back on deep drives was legendary, and Hall of Fame teammate Brooks Robinson called him the best defensive outfielder he ever saw. Blair's defensive prowess was so respected that the term &quot;No-Fly Zone&quot; was often used to describe his territory.">
            With eight Gold Gloves, what made Paul Blair such a renowned defensive center fielder?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His most crucial contribution came in the decisive Game 5 of the 1977 ALCS against the Kansas City Royals. Entering the game late, Blair hit a game-tying, bases-loaded single in the eighth inning. He then scored the go-ahead run in the top of the ninth, helping propel the Yankees to the World Series.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="His most crucial contribution came in the decisive Game 5 of the 1977 ALCS against the Kansas City Royals. Entering the game late, Blair hit a game-tying, bases-loaded single in the eighth inning. He then scored the go-ahead run in the top of the ninth, helping propel the Yankees to the World Series.">
            What was Paul Blair's most significant moment during the Yankees' championship runs in the late 1970s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer='Yes, he was widely known by the nickname "Motormouth" for his constant chatter on the field. Teammates and opponents noted that Blair talked incessantly during games, often to himself or even to the baseball. This habit was a signature part of his energetic and distinctive personality throughout his career.'>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer='Yes, he was widely known by the nickname "Motormouth" for his constant chatter on the field. Teammates and opponents noted that Blair talked incessantly during games, often to himself or even to the baseball. This habit was a signature part of his energetic and distinctive personality throughout his career.'>
            Did Paul Blair have any memorable nicknames or on-field habits?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            37.7
           </td>
-          <td>
+<td>
            6042
           </td>
-          <td>
+<td>
            1513
           </td>
-          <td>
+<td>
            134
           </td>
-          <td>
+<td>
            .250
           </td>
-          <td>
+<td>
            776
           </td>
-          <td>
+<td>
            620
           </td>
-          <td>
+<td>
            171
           </td>
-          <td>
+<td>
            .302
           </td>
-          <td>
+<td>
            .382
           </td>
-          <td>
+<td>
            .684
           </td>
-          <td>
+<td>
            96
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1964", "1965", "1966", "1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980"];
             const warData = [-0.2, 0.5, 2.0, 6.8, 2.2, 7.1, 5.9, 2.9, 2.5, 4.9, 5.3, 0.9, -1.1, 0.5, -0.8, -1.6, 0.0];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "NYY", "NYY", "2TM", "NYY"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "BAL", "CIN"], "years": ["1976", "1969", "1975", "1964", "1967", "1966", "1968", "1970", "1971", "1973", "1977", "1978", "1979", "1965", "1980", "1974", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul Blair", "hints": ["Won eight Gold Glove Awards as an outfielder.", "Won four World Series championships with the Orioles and Yankees.", "Batted .474 with nine hits in the 1970 World Series."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-19.html
+++ b/2025-09-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul Blair.">
   <title>
    Paul Blair Answer - September 19, 2025 | Name That Yankee
   </title>

--- a/2025-09-20.html
+++ b/2025-09-20.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-20" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-20" rel="canonical"/><meta content="Discover the career highlights and statistics for Elliott Maddox, the featured New York Yankee for the 2025-09-20 trivia puzzle." name="description"/>
+
+<title>
    Elliott Maddox Answer - September 20, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 20, 2025: Elliott Maddox. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 20, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-20.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 20, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-20.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 20, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-20.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 20, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-20.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-20"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 20, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Elliott Maddox" src="images/answer-2025-09-20.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Elliott Maddox" src="images/answer-2025-09-20.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Elliott Maddox
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Finished third in the 1970 American League Rookie of the Year voting.
         </li>
-        <li>
+<li>
          Led the American League in times on base with 265 in 1974.
         </li>
-        <li>
+<li>
          Sued the City of New York after a career-altering knee injury at Shea Stadium in 1975.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Elliott Maddox?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Elliott Maddox was a versatile player who began as a third baseman with the Detroit Tigers before converting to a full-time outfielder. After being traded to the Yankees, he had a breakout 1974 season where he hit .303, played a stellar center field, and finished eighth in the AL MVP voting. His career was tragically altered by a severe knee injury the following season, preventing him from building on that success.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Elliott Maddox was a versatile player who began as a third baseman with the Detroit Tigers before converting to a full-time outfielder. After being traded to the Yankees, he had a breakout 1974 season where he hit .303, played a stellar center field, and finished eighth in the AL MVP voting. His career was tragically altered by a severe knee injury the following season, preventing him from building on that success.">
            Beyond his great 1974 season, what defined Elliott Maddox's career before his injury derailed it?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="In his first year in pinstripes, Maddox was a revelation, posting career highs in batting average (.303), on-base percentage (.394), and hits (149). He led the entire American League in times on base with 265, showcasing elite plate discipline. This performance earned him an eighth-place finish in the AL MVP race.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In his first year in pinstripes, Maddox was a revelation, posting career highs in batting average (.303), on-base percentage (.394), and hits (149). He led the entire American League in times on base with 265, showcasing elite plate discipline. This performance earned him an eighth-place finish in the AL MVP race.">
            How impressive was Elliott Maddox's 1974 season, his first year with the Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="During a 1975 game at Shea Stadium, where the Yankees played while their stadium was renovated, Maddox slipped on a poorly drained patch of outfield grass and severely injured his knee. He sued the City of New York for negligent maintenance of the field. A jury found the city liable, and Maddox was awarded a settlement for the career-altering injury.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During a 1975 game at Shea Stadium, where the Yankees played while their stadium was renovated, Maddox slipped on a poorly drained patch of outfield grass and severely injured his knee. He sued the City of New York for negligent maintenance of the field. A jury found the city liable, and Maddox was awarded a settlement for the career-altering injury.">
            What was the story behind Elliott Maddox's lawsuit against New York City after his injury at Shea Stadium?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.9
           </td>
-          <td>
+<td>
            2843
           </td>
-          <td>
+<td>
            742
           </td>
-          <td>
+<td>
            18
           </td>
-          <td>
+<td>
            .261
           </td>
-          <td>
+<td>
            360
           </td>
-          <td>
+<td>
            234
           </td>
-          <td>
+<td>
            60
           </td>
-          <td>
+<td>
            .358
           </td>
-          <td>
+<td>
            .334
           </td>
-          <td>
+<td>
            .692
           </td>
-          <td>
+<td>
            100
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-20.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-20.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980"];
             const warData = [0.1, 1.4, 2.5, 0.0, 5.4, 2.5, -0.4, 0.8, 0.9, 0.0, 1.7];
             const teamsByYear = ["DET", "WSA", "TEX", "TEX", "NYY", "NYY", "NYY", "BAL", "NYM", "NYM", "NYM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TEX", "NYY", "NYM", "BAL", "WSA", "DET"], "years": ["1976", "1975", "1973", "1971", "1970", "1977", "1978", "1979", "1980", "1974", "1972"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Elliott Maddox", "hints": ["Finished third in the 1970 American League Rookie of the Year voting.", "Led the American League in times on base with 265 in 1974.", "Sued the City of New York after a career-altering knee injury at Shea Stadium in 1975."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-20.html
+++ b/2025-09-20.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-20" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Elliott Maddox.">
   <title>
    Elliott Maddox Answer - September 20, 2025 | Name That Yankee
   </title>

--- a/2025-09-21.html
+++ b/2025-09-21.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-21" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-21" rel="canonical"/><meta content="Discover the career highlights and statistics for Mike Mussina, the featured New York Yankee for the 2025-09-21 trivia puzzle." name="description"/>
+
+<title>
    Mike Mussina Answer - September 21, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 21, 2025: Mike Mussina. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 21, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-21.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 21, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-21.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 21, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-21.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 21, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-21.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-21"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 21, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Mike Mussina" src="images/answer-2025-09-21.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mike Mussina" src="images/answer-2025-09-21.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Mike Mussina "Moose"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Became the oldest first-time 20-game winner in MLB history at age 39.
         </li>
-        <li>
+<li>
          Was elected to the Hall of Fame without winning a Cy Young Award or 300 games.
         </li>
-        <li>
+<li>
          Won seven Gold Glove Awards.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Mike Mussina?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Mike Mussina's Hall of Fame case is built on sustained excellence and consistency. He won 270 games and finished with a career WAR of 82.9, pitching his entire career in the high-offense American League East during the steroid era. While he never won the Cy Young, he finished in the top six of the voting nine different times.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Mike Mussina's Hall of Fame case is built on sustained excellence and consistency. He won 270 games and finished with a career WAR of 82.9, pitching his entire career in the high-offense American League East during the steroid era. While he never won the Cy Young, he finished in the top six of the voting nine different times.">
            Considering he never won a Cy Young Award, what made Mike Mussina's career worthy of the Hall of Fame?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="His most iconic Yankees moment came in Game 7 of the 2003 ALCS against the Red Sox. Making the first relief appearance of his career on just two days' rest, Mussina entered a bases-loaded, no-out jam and escaped without allowing a run. He pitched three scoreless innings, stabilizing the game and setting the stage for the Yankees' eventual comeback victory.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="His most iconic Yankees moment came in Game 7 of the 2003 ALCS against the Red Sox. Making the first relief appearance of his career on just two days' rest, Mussina entered a bases-loaded, no-out jam and escaped without allowing a run. He pitched three scoreless innings, stabilizing the game and setting the stage for the Yankees' eventual comeback victory.">
            What was Mike Mussina's most memorable postseason performance as a Yankee?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Mussina was known for his intelligence, having graduated from Stanford University with a degree in economics in just three and a half years. He is a renowned crossword puzzle enthusiast and was even inducted into the Crossword Puzzle Hall of Fame. Since retiring, he has also served as the head basketball coach for the high school in his hometown of Montoursville, Pennsylvania.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Mussina was known for his intelligence, having graduated from Stanford University with a degree in economics in just three and a half years. He is a renowned crossword puzzle enthusiast and was even inducted into the Crossword Puzzle Hall of Fame. Since retiring, he has also served as the head basketball coach for the high school in his hometown of Montoursville, Pennsylvania.">
            What were some of Mike Mussina's notable interests or talents off the field?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            82.8
           </td>
-          <td>
+<td>
            270
           </td>
-          <td>
+<td>
            153
           </td>
-          <td>
+<td>
            3.68
           </td>
-          <td>
+<td>
            537
           </td>
-          <td>
+<td>
            536
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            3562.2
           </td>
-          <td>
+<td>
            2813
           </td>
-          <td>
+<td>
            1.192
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-21.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-21.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008"];
             const warData = [2.2, 8.2, 1.6, 5.4, 6.1, 3.7, 5.5, 5.0, 4.4, 5.7, 7.1, 4.5, 6.6, 2.4, 3.4, 5.0, 1.0, 5.1];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "BAL"], "years": ["1997", "1992", "1996", "1993", "2000", "1995", "2001", "2007", "2003", "1999", "2006", "2005", "1998", "1994", "1991", "2002", "2008", "2004"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Mike Mussina", "hints": ["Became the oldest first-time 20-game winner in MLB history at age 39.", "Was elected to the Hall of Fame without winning a Cy Young Award or 300 games.", "Won seven Gold Glove Awards."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-21.html
+++ b/2025-09-21.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-21" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mike Mussina.">
   <title>
    Mike Mussina Answer - September 21, 2025 | Name That Yankee
   </title>

--- a/2025-09-23.html
+++ b/2025-09-23.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-23" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Nick Swisher.">
   <title>
    Nick Swisher Answer - September 23, 2025 | Name That Yankee
   </title>

--- a/2025-09-23.html
+++ b/2025-09-23.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-23" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-23" rel="canonical"/><meta content="Discover the career highlights and statistics for Nick Swisher, the featured New York Yankee for the 2025-09-23 trivia puzzle." name="description"/>
+
+<title>
    Nick Swisher Answer - September 23, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 23, 2025: Nick Swisher. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 23, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-23.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 23, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-23.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 23, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-23.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 23, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-23.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-23"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 23, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Nick Swisher" src="images/answer-2025-09-23.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Nick Swisher" src="images/answer-2025-09-23.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Nick Swisher "Swish"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Father was an MLB All-Star catcher.
         </li>
-        <li>
+<li>
          Won a World Series with the New York Yankees in 2009.
         </li>
-        <li>
+<li>
          Hit a home run from both sides of the plate in the same game 14 times.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Nick Swisher?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Nick Swisher was a 2010 All-Star and a consistent power threat, hitting at least 20 home runs for nine consecutive seasons (2005-2013). As a switch-hitter, he holds the MLB record for hitting a home run from both sides of the plate in the same game, accomplishing the feat 14 times. He finished his career with 245 home runs and a high walk rate, resulting in a solid .351 on-base percentage.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Nick Swisher was a 2010 All-Star and a consistent power threat, hitting at least 20 home runs for nine consecutive seasons (2005-2013). As a switch-hitter, he holds the MLB record for hitting a home run from both sides of the plate in the same game, accomplishing the feat 14 times. He finished his career with 245 home runs and a high walk rate, resulting in a solid .351 on-base percentage.">
            Beyond his World Series ring, what were Nick Swisher's most significant career accomplishments?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="While he was a key part of the 2009 championship team, Swisher struggled at the plate for most of that postseason, batting just .173 overall. However, he delivered a crucial walk-off single in the 13th inning of Game 2 of the ALCS against the Angels. He also hit a solo home run in Game 3 of the World Series against the Phillies.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="While he was a key part of the 2009 championship team, Swisher struggled at the plate for most of that postseason, batting just .173 overall. However, he delivered a crucial walk-off single in the 13th inning of Game 2 of the ALCS against the Angels. He also hit a solo home run in Game 3 of the World Series against the Phillies.">
            How did Nick Swisher perform during the Yankees' 2009 World Series run?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Swisher's signature salute to the dugout after reaching base was a tribute to members of the U.S. military. He began the gesture after returning from a USO tour to visit troops in Iraq during the 2008 offseason. The celebration became an iconic part of his energetic and fan-friendly personality, particularly during his time in New York.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Swisher's signature salute to the dugout after reaching base was a tribute to members of the U.S. military. He began the gesture after returning from a USO tour to visit troops in Iraq during the 2008 offseason. The celebration became an iconic part of his energetic and fan-friendly personality, particularly during his time in New York.">
            What was the story behind Nick Swisher's famous 'Swisher Salute' celebration?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            21.5
           </td>
-          <td>
+<td>
            5369
           </td>
-          <td>
+<td>
            1338
           </td>
-          <td>
+<td>
            245
           </td>
-          <td>
+<td>
            .249
           </td>
-          <td>
+<td>
            805
           </td>
-          <td>
+<td>
            803
           </td>
-          <td>
+<td>
            13
           </td>
-          <td>
+<td>
            .351
           </td>
-          <td>
+<td>
            .447
           </td>
-          <td>
+<td>
            .799
           </td>
-          <td>
+<td>
            113
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-23.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-23.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2004", "2005", "2006", "2007", "2008", "2009", "2010", "2011", "2012", "2013", "2014", "2015"];
             const warData = [-0.4, 1.7, 3.5, 4.4, -0.2, 1.9, 3.8, 2.2, 4.0, 3.7, -1.8, -1.3];
             const teamsByYear = ["OAK", "OAK", "OAK", "OAK", "CHW", "NYY", "NYY", "NYY", "NYY", "CLE", "CLE", "2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CLE", "CHW", "ATL", "OAK"], "years": ["2013", "2007", "2009", "2006", "2005", "2012", "2015", "2010", "2011", "2014", "2008", "2004"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Nick Swisher", "hints": ["Father was an MLB All-Star catcher.", "Won a World Series with the New York Yankees in 2009.", "Hit a home run from both sides of the plate in the same game 14 times."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-24.html
+++ b/2025-09-24.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-24" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Joel Skinner.">
   <title>
    Joel Skinner Answer - September 24, 2025 | Name That Yankee
   </title>

--- a/2025-09-24.html
+++ b/2025-09-24.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-24" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-24" rel="canonical"/><meta content="Discover the career highlights and statistics for Joel Skinner, the featured New York Yankee for the 2025-09-24 trivia puzzle." name="description"/>
+
+<title>
    Joel Skinner Answer - September 24, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 24, 2025: Joel Skinner. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 24, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-24.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 24, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-24.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 24, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-24.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 24, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-24.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-24"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 24, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Joel Skinner" src="images/answer-2025-09-24.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Joel Skinner" src="images/answer-2025-09-24.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Joel Skinner
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Father, Bob Skinner, was a two-time MLB All-Star and 1960 World Series champion.
         </li>
-        <li>
+<li>
          Caught Joe Cowley's no-hitter on September 19, 1986.
         </li>
-        <li>
+<li>
          Served as interim manager for the Cleveland Indians for 76 games in 2002.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Joel Skinner?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Joel Skinner was primarily known as a solid defensive catcher with a strong and accurate throwing arm. Throughout his career, he threw out 35% of would-be base stealers, a rate consistently above the league average of his era. While his defense was his calling card, he was a light-hitting catcher, finishing his nine-year career with a .222 batting average.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Joel Skinner was primarily known as a solid defensive catcher with a strong and accurate throwing arm. Throughout his career, he threw out 35% of would-be base stealers, a rate consistently above the league average of his era. While his defense was his calling card, he was a light-hitting catcher, finishing his nine-year career with a .222 batting average.">
            Beyond catching a no-hitter, what was Joel Skinner's reputation as a player?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The Yankees acquired Joel Skinner from the Chicago White Sox in a mid-season trade on July 30, 1986. He was part of a package deal that also brought Ron Kittle and Wayne Tolleson to New York in exchange for Ron Hassey and Carlos Martinez. Skinner served as a backup catcher for the Yankees for parts of three seasons from 1986 to 1988.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The Yankees acquired Joel Skinner from the Chicago White Sox in a mid-season trade on July 30, 1986. He was part of a package deal that also brought Ron Kittle and Wayne Tolleson to New York in exchange for Ron Hassey and Carlos Martinez. Skinner served as a backup catcher for the Yankees for parts of three seasons from 1986 to 1988.">
            How did Joel Skinner first become a member of the New York Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Joel Skinner was a second-generation major leaguer, as his father, Bob Skinner, was a two-time All-Star outfielder and a member of the 1960 World Series champion Pittsburgh Pirates. The two are also part of a select group of fathers and sons who have both managed in the major leagues. Bob managed the Philadelphia Phillies in the late 1960s, while Joel served as the interim manager for the Cleveland Indians in 2002.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Joel Skinner was a second-generation major leaguer, as his father, Bob Skinner, was a two-time All-Star outfielder and a member of the 1960 World Series champion Pittsburgh Pirates. The two are also part of a select group of fathers and sons who have both managed in the major leagues. Bob managed the Philadelphia Phillies in the late 1960s, while Joel served as the interim manager for the Cleveland Indians in 2002.">
            What was unique about Joel Skinner's family connection to professional baseball?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -0.1
           </td>
-          <td>
+<td>
            1441
           </td>
-          <td>
+<td>
            329
           </td>
-          <td>
+<td>
            17
           </td>
-          <td>
+<td>
            .228
           </td>
-          <td>
+<td>
            119
           </td>
-          <td>
+<td>
            136
           </td>
-          <td>
+<td>
            3
           </td>
-          <td>
+<td>
            .269
           </td>
-          <td>
+<td>
            .311
           </td>
-          <td>
+<td>
            .580
           </td>
-          <td>
+<td>
            60
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-24.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-24.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991"];
             const warData = [0.1, -0.5, 0.5, -0.3, -1.0, 0.6, -0.1, 0.5, 0.3];
             const teamsByYear = ["CHW", "CHW", "CHW", "2TM", "NYY", "NYY", "CLE", "CLE", "CLE"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CLE", "CHW"], "years": ["1985", "1988", "1986", "1990", "1989", "1983", "1984", "1987", "1991"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Joel Skinner", "hints": ["Father, Bob Skinner, was a two-time MLB All-Star and 1960 World Series champion.", "Caught Joe Cowley's no-hitter on September 19, 1986.", "Served as interim manager for the Cleveland Indians for 76 games in 2002."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-25.html
+++ b/2025-09-25.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-25" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Richard Dotson.">
   <title>
    Richard Dotson Answer - September 25, 2025 | Name That Yankee
   </title>

--- a/2025-09-25.html
+++ b/2025-09-25.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-25" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-25" rel="canonical"/><meta content="Discover the career highlights and statistics for Richard Dotson, the featured New York Yankee for the 2025-09-25 trivia puzzle." name="description"/>
+
+<title>
    Richard Dotson Answer - September 25, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 25, 2025: Richard Dotson. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 25, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-25.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 25, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-25.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 25, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-25.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 25, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-25.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-25"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 25, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Richard Dotson" src="images/answer-2025-09-25.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Richard Dotson" src="images/answer-2025-09-25.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Richard Dotson
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Led the American League in wins with 22 in 1983.
         </li>
-        <li>
+<li>
          Was selected to the American League All-Star team in 1984.
         </li>
-        <li>
+<li>
          Led the American League in shutouts with four in 1981.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Richard Dotson?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer='Richard Dotson was a durable workhorse for the Chicago White Sox in the early 1980s, peaking with his All-Star season in 1984. His 1983 performance, where he finished fourth in Cy Young voting, helped lead the "Winning Ugly" White Sox to an AL West title. Though a 1985 chest muscle injury hampered his trajectory, he remained a dependable innings-eater for the Yankees and a second stint with Chicago.'>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer='Richard Dotson was a durable workhorse for the Chicago White Sox in the early 1980s, peaking with his All-Star season in 1984. His 1983 performance, where he finished fourth in Cy Young voting, helped lead the "Winning Ugly" White Sox to an AL West title. Though a 1985 chest muscle injury hampered his trajectory, he remained a dependable innings-eater for the Yankees and a second stint with Chicago.'>
            Beyond his 22-win season in 1983, what was the overall arc of Richard Dotson's career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The Yankees acquired Dotson from the White Sox in a 1987 mid-season trade for outfielder Dan Pasqua. He pitched effectively for New York, posting a 12-9 record with a 3.99 ERA in 1988, his only full season with the club. He was traded back to the White Sox during the 1989 season.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The Yankees acquired Dotson from the White Sox in a 1987 mid-season trade for outfielder Dan Pasqua. He pitched effectively for New York, posting a 12-9 record with a 3.99 ERA in 1988, his only full season with the club. He was traded back to the White Sox during the 1989 season.">
            How did Richard Dotson perform after being traded to the Yankees during their late-80s playoff drought?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After retiring as a player, Richard Dotson remained in baseball as a coach within the Chicago White Sox organization. For over a decade, he served as a pitching coach for various minor league affiliates, including the Charlotte Knights and Birmingham Barons. In this role, he helped mentor the next generation of White Sox pitchers.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring as a player, Richard Dotson remained in baseball as a coach within the Chicago White Sox organization. For over a decade, he served as a pitching coach for various minor league affiliates, including the Charlotte Knights and Birmingham Barons. In this role, he helped mentor the next generation of White Sox pitchers.">
            What did Richard Dotson do after his playing days were over?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            15.9
           </td>
-          <td>
+<td>
            111
           </td>
-          <td>
+<td>
            113
           </td>
-          <td>
+<td>
            4.23
           </td>
-          <td>
+<td>
            305
           </td>
-          <td>
+<td>
            295
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            1857.1
           </td>
-          <td>
+<td>
            973
           </td>
-          <td>
+<td>
            1.413
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-25.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-25.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990"];
             const warData = [0.0, 1.7, 1.0, 2.8, 5.1, 4.3, 0.4, -0.5, 2.0, -0.2, 0.4, -0.9];
             const teamsByYear = ["CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "CHW", "NYY", "2TM", "KCR"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "KCR", "CHW"], "years": ["1985", "1981", "1988", "1986", "1990", "1989", "1979", "1982", "1983", "1984", "1987", "1980"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Richard Dotson", "hints": ["Led the American League in wins with 22 in 1983.", "Was selected to the American League All-Star team in 1984.", "Led the American League in shutouts with four in 1981."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-26.html
+++ b/2025-09-26.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-26" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Gene Woodling.">
   <title>
    Gene Woodling Answer - September 26, 2025 | Name That Yankee
   </title>

--- a/2025-09-26.html
+++ b/2025-09-26.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-26" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-26" rel="canonical"/><meta content="Discover the career highlights and statistics for Gene Woodling, the featured New York Yankee for the 2025-09-26 trivia puzzle." name="description"/>
+
+<title>
    Gene Woodling Answer - September 26, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 26, 2025: Gene Woodling. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 26, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-26.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 26, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-26.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 26, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-26.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 26, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-26.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2025-09-26"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 26, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Gene Woodling" src="images/answer-2025-09-26.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Gene Woodling" src="images/answer-2025-09-26.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Gene Woodling "Old Faithful"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won five consecutive World Series championships from 1949 to 1953.
         </li>
-        <li>
+<li>
          Hit the first home run in the history of the modern Baltimore Orioles franchise in 1954.
         </li>
-        <li>
+<li>
          Pinch-hit for Roger Maris in Maris's first major league at-bat.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Gene Woodling?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Gene Woodling was a left-handed hitting outfielder best known for his outstanding plate discipline and high on-base percentage, finishing his career with more walks than strikeouts. Manager Casey Stengel often used him in a successful platoon system, primarily against right-handed pitchers. He was also a reliable defensive player with a strong arm, making him a valuable all-around contributor.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Gene Woodling was a left-handed hitting outfielder best known for his outstanding plate discipline and high on-base percentage, finishing his career with more walks than strikeouts. Manager Casey Stengel often used him in a successful platoon system, primarily against right-handed pitchers. He was also a reliable defensive player with a strong arm, making him a valuable all-around contributor.">
            What defined Gene Woodling's playing style throughout his 17-year career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Woodling was a clutch postseason performer for the Yankees during their championship dynasty. Across the 22 World Series games he played from 1949 to 1953, he batted .318 with three home runs and 11 RBI. His key moments included hitting .429 in the 1949 Series and a crucial home run in the 1951 Fall Classic.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Woodling was a clutch postseason performer for the Yankees during their championship dynasty. Across the 22 World Series games he played from 1949 to 1953, he batted .318 with three home runs and 11 RBI. His key moments included hitting .429 in the 1949 Series and a crucial home run in the 1951 Fall Classic.">
            How did Gene Woodling perform for the Yankees during their five consecutive World Series championships?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, Woodling's career was paused for service in the U.S. Navy during World War II. While serving in the Pacific, he suffered significant injuries, including losing the top of his right thumb in an accident. Despite this, he successfully rehabilitated and returned to baseball, making his major league debut after the war.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, Woodling's career was paused for service in the U.S. Navy during World War II. While serving in the Pacific, he suffered significant injuries, including losing the top of his right thumb in an accident. Despite this, he successfully rehabilitated and returned to baseball, making his major league debut after the war.">
            Did Gene Woodling's career get interrupted by military service?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            33.3
           </td>
-          <td>
+<td>
            5587
           </td>
-          <td>
+<td>
            1585
           </td>
-          <td>
+<td>
            147
           </td>
-          <td>
+<td>
            .284
           </td>
-          <td>
+<td>
            830
           </td>
-          <td>
+<td>
            830
           </td>
-          <td>
+<td>
            29
           </td>
-          <td>
+<td>
            .386
           </td>
-          <td>
+<td>
            .431
           </td>
-          <td>
+<td>
            .817
           </td>
-          <td>
+<td>
            123
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-26.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-26.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1943", "1946", "1947", "1949", "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962"];
             const warData = [0.3, -0.4, 0.1, 1.3, 2.4, 3.4, 4.1, 4.3, 0.8, -0.1, 1.1, 4.6, 2.6, 3.1, 3.1, 1.6, 1.2];
             const teamsByYear = ["CLE", "CLE", "PIT", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "2TM", "CLE", "CLE", "BAL", "BAL", "BAL", "WSA", "2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["CLE", "NYY", "NYM", "BAL", "WSA", "PIT"], "years": ["1947", "1956", "1955", "1954", "1957", "1959", "1953", "1943", "1946", "1950", "1952", "1961", "1958", "1962", "1960", "1951", "1949"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Gene Woodling", "hints": ["Won five consecutive World Series championships from 1949 to 1953.", "Hit the first home run in the history of the modern Baltimore Orioles franchise in 1954.", "Pinch-hit for Roger Maris in Maris's first major league at-bat."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-27.html
+++ b/2025-09-27.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-27" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Bobby Shantz, the featured New York Yankee for the 2025-09-27 trivia puzzle." name="description"/>
+
+<title>
    Bobby Shantz Answer - September 27, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 27, 2025: Bobby Shantz. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 27, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-27.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 27, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-27.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 27, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 27, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-27.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-27"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 27, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Bobby Shantz" src="images/answer-2025-09-27.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bobby Shantz" src="images/answer-2025-09-27.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Bobby Shantz "The Little Lefty"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won the 1952 American League MVP award.
         </li>
-        <li>
+<li>
          Won eight consecutive Gold Glove awards from 1957 to 1964.
         </li>
-        <li>
+<li>
          Was a teammate of his brother, Billy, on the Athletics and Yankees.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Bobby Shantz?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Standing just 5-foot-6, Bobby Shantz had a phenomenal 1952 season for the Philadelphia Athletics, going 24–7 with a 2.48 ERA and leading the league in wins. His MVP award was a testament to his dominance despite his small stature. He was also widely regarded as the best-fielding pitcher of his time, a skill later recognized when he won the first of eight consecutive Gold Gloves in 1957.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Standing just 5-foot-6, Bobby Shantz had a phenomenal 1952 season for the Philadelphia Athletics, going 24–7 with a 2.48 ERA and leading the league in wins. His MVP award was a testament to his dominance despite his small stature. He was also widely regarded as the best-fielding pitcher of his time, a skill later recognized when he won the first of eight consecutive Gold Gloves in 1957.">
            Considering he was a pitcher, what made Bobby Shantz's 1952 MVP season and his defensive prowess so remarkable?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Shantz was a key swingman for the Yankees in three World Series. He pitched 5.1 scoreless relief innings to help the Yankees win the 1958 World Series against the Braves. In the dramatic 1960 World Series against the Pirates, he earned the win in Game 3 after pitching three scoreless innings in relief.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Shantz was a key swingman for the Yankees in three World Series. He pitched 5.1 scoreless relief innings to help the Yankees win the 1958 World Series against the Braves. In the dramatic 1960 World Series against the Pirates, he earned the win in Game 3 after pitching three scoreless innings in relief.">
            What was Bobby Shantz's role during the Yankees' World Series appearances in the late 1950s?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Bobby's younger brother, Billy Shantz, was a catcher, and the two formed a rare &quot;brother battery.&quot; They first played as pitcher and catcher together with the Philadelphia Athletics in 1954. The pair were later reunited on the Yankees, where Billy occasionally caught for his older brother.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Bobby's younger brother, Billy Shantz, was a catcher, and the two formed a rare &quot;brother battery.&quot; They first played as pitcher and catcher together with the Philadelphia Athletics in 1954. The pair were later reunited on the Yankees, where Billy occasionally caught for his older brother.">
            What was so unusual about Bobby Shantz's relationship with his brother and teammate, Billy?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            34.6
           </td>
-          <td>
+<td>
            119
           </td>
-          <td>
+<td>
            99
           </td>
-          <td>
+<td>
            3.38
           </td>
-          <td>
+<td>
            537
           </td>
-          <td>
+<td>
            171
           </td>
-          <td>
+<td>
            48
           </td>
-          <td>
+<td>
            1935.2
           </td>
-          <td>
+<td>
            1072
           </td>
-          <td>
+<td>
            1.260
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-27.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["1949", "1950", "1951", "1952", "1953", "1954", "1955", "1956", "1957", "1958", "1959", "1960", "1961", "1962", "1963", "1964"];
             const warData = [2.1, 2.3, 2.4, 8.8, 1.8, -0.1, 0.6, 1.3, 3.1, 0.4, 1.9, 0.9, 1.6, 2.3, 1.5, 1.2];
             const teamsByYear = ["PHA", "PHA", "PHA", "PHA", "PHA", "PHA", "KCA", "KCA", "NYY", "NYY", "NYY", "NYY", "PIT", "2TM", "STL", "3TM"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "STL", "HOU", "PHA", "KCA", "PHI", "PIT", "CHC"], "years": ["1956", "1963", "1955", "1954", "1957", "1964", "1959", "1953", "1952", "1950", "1961", "1958", "1962", "1960", "1951", "1949"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Bobby Shantz", "hints": ["Won the 1952 American League MVP award.", "Won eight consecutive Gold Glove awards from 1957 to 1964.", "Was a teammate of his brother, Billy, on the Athletics and Yankees."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2025-09-27.html
+++ b/2025-09-27.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-27" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bobby Shantz.">
   <title>
    Bobby Shantz Answer - September 27, 2025 | Name That Yankee
   </title>

--- a/2025-09-28.html
+++ b/2025-09-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2025-09-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Zach Britton.">
   <title>
    Zach Britton Answer - September 28, 2025 | Name That Yankee
   </title>

--- a/2025-09-28.html
+++ b/2025-09-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2025-09-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2025-09-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Zach Britton, the featured New York Yankee for the 2025-09-28 trivia puzzle." name="description"/>
+
+<title>
    Zach Britton Answer - September 28, 2025 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on September 28, 2025: Zach Britton. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - September 28, 2025" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2025-09-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - September 28, 2025" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2025-09-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - September 28, 2025" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2025-09-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - September 28, 2025" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2025-09-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2025-09-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for September 28, 2025 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Zach Britton" src="images/answer-2025-09-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Zach Britton" src="images/answer-2025-09-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Zach Britton
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Recorded a 0.54 ERA in 2016, the lowest in MLB history for a pitcher with at least 50 innings.
         </li>
-        <li>
+<li>
          Set an American League record by converting 60 consecutive save opportunities from 2015 to 2017.
         </li>
-        <li>
+<li>
          Began career as a starting pitcher before converting to a reliever in 2014.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Zach Britton?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Zach Britton's dominance stemmed from a two-seam fastball, or sinker, that was unlike any other in the game. He threw it with elite velocity, averaging 95-97 mph, combined with extreme horizontal and vertical movement. This pitch induced an unprecedented number of ground balls; during his historic 2016 season, his ground ball rate was an astonishing 80%.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Zach Britton's dominance stemmed from a two-seam fastball, or sinker, that was unlike any other in the game. He threw it with elite velocity, averaging 95-97 mph, combined with extreme horizontal and vertical movement. This pitch induced an unprecedented number of ground balls; during his historic 2016 season, his ground ball rate was an astonishing 80%.">
            Beyond his record-setting ERA, what made Zach Britton's sinker so uniquely effective during his peak?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After being acquired in 2018, Britton became a vital high-leverage setup man for the Yankees, typically pitching the eighth inning ahead of closer Aroldis Chapman. He was a reliable presence in four different postseasons for New York (2018, 2019, 2020, 2022). In 14 total postseason appearances for the Yankees, he posted a 2.79 ERA, solidifying his role as a key bridge to the ninth inning.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After being acquired in 2018, Britton became a vital high-leverage setup man for the Yankees, typically pitching the eighth inning ahead of closer Aroldis Chapman. He was a reliable presence in four different postseasons for New York (2018, 2019, 2020, 2022). In 14 total postseason appearances for the Yankees, he posted a 2.79 ERA, solidifying his role as a key bridge to the ninth inning.">
            What was Zach Britton's role in the Yankees' bullpen during their postseason runs?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Yes, his older brother, Buck Britton, has had a long career in professional baseball. Buck was a minor league infielder for nine seasons, primarily in the Baltimore Orioles' farm system. After his playing days ended, he transitioned into coaching and has served as a successful minor league manager, also within the Orioles organization.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, his older brother, Buck Britton, has had a long career in professional baseball. Buck was a minor league infielder for nine seasons, primarily in the Baltimore Orioles' farm system. After his playing days ended, he transitioned into coaching and has served as a successful minor league manager, also within the Orioles organization.">
            Does Zach Britton have any other family members involved in professional baseball?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.0
           </td>
-          <td>
+<td>
            35
           </td>
-          <td>
+<td>
            26
           </td>
-          <td>
+<td>
            3.13
           </td>
-          <td>
+<td>
            442
           </td>
-          <td>
+<td>
            46
           </td>
-          <td>
+<td>
            154
           </td>
-          <td>
+<td>
            641.0
           </td>
-          <td>
+<td>
            532
           </td>
-          <td>
+<td>
            1.264
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2025-09-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2025-09-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022"];
             const warData = [0.4, 0.1, 0.0, 2.6, 2.3, 4.1, 1.0, 0.6, 2.5, 0.5, -0.4, -0.1];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "2TM", "NYY", "NYY", "NYY", "NYY"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "BAL"], "years": ["2013", "2022", "2018", "2020", "2017", "2016", "2019", "2015", "2021", "2011", "2012", "2014"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Zach Britton", "hints": ["Recorded a 0.54 ERA in 2016, the lowest in MLB history for a pitcher with at least 50 innings.", "Set an American League record by converting 60 consecutive save opportunities from 2015 to 2017.", "Began career as a starting pitcher before converting to a reliever in 2014."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-02-28.html
+++ b/2026-02-28.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-02-28" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Amed Rosario.">
   <title>
    Amed Rosario Answer - February 28, 2026 | Name That Yankee
   </title>

--- a/2026-02-28.html
+++ b/2026-02-28.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-02-28" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-02-28" rel="canonical"/><meta content="Discover the career highlights and statistics for Amed Rosario, the featured New York Yankee for the 2026-02-28 trivia puzzle." name="description"/>
+
+<title>
    Amed Rosario Answer - February 28, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on February 28, 2026: Amed Rosario. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - February 28, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-02-28.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - February 28, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-02-28.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - February 28, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-02-28.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - February 28, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-02-28.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2026-02-28"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for February 28, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Amed Rosario" src="images/answer-2026-02-28.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Amed Rosario" src="images/answer-2026-02-28.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Amed Rosario
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Ranked as the number one overall prospect by Baseball Prospectus before the 2017 season.
         </li>
-        <li>
+<li>
          Led the major leagues in triples in both 2018 and 2022.
         </li>
-        <li>
+<li>
          Was the main player acquired by Cleveland in the trade that sent Francisco Lindor to the New York Mets.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Amed Rosario?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After debuting with the Mets, he became their starting shortstop and led the league in triples in 2018. He was the key player traded to Cleveland for Francisco Lindor in 2021, where he had a career-best season in 2022. Since then, he has served as a versatile utility player for the Dodgers, Rays, and Yankees.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After debuting with the Mets, he became their starting shortstop and led the league in triples in 2018. He was the key player traded to Cleveland for Francisco Lindor in 2021, where he had a career-best season in 2022. Since then, he has served as a versatile utility player for the Dodgers, Rays, and Yankees.">
            What has Amed Rosario's career trajectory been like since he was a top prospect?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The Yankees acquired Amed Rosario from the Tampa Bay Rays before the 2024 trade deadline to add a versatile, right-handed bat to their bench. His experience playing shortstop, second base, and outfield provided valuable depth and injury insurance for the team's postseason run.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The Yankees acquired Amed Rosario from the Tampa Bay Rays before the 2024 trade deadline to add a versatile, right-handed bat to their bench. His experience playing shortstop, second base, and outfield provided valuable depth and injury insurance for the team's postseason run.">
            Why did the Yankees acquire him during the 2024 season?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer='Rosario is widely known by the nickname "El Niño," which translates to "The Kid." He is also recognized for his frequently changing and distinctive hairstyles, which have been a topic of conversation among fans throughout his career.'>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer='Rosario is widely known by the nickname "El Niño," which translates to "The Kid." He is also recognized for his frequently changing and distinctive hairstyles, which have been a topic of conversation among fans throughout his career.'>
            Does he have any interesting off-field hobbies or nicknames?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            10.2
           </td>
-          <td>
+<td>
            3688
           </td>
-          <td>
+<td>
            1008
           </td>
-          <td>
+<td>
            69
           </td>
-          <td>
+<td>
            .273
           </td>
-          <td>
+<td>
            469
           </td>
-          <td>
+<td>
            389
           </td>
-          <td>
+<td>
            110
           </td>
-          <td>
+<td>
            .308
           </td>
-          <td>
+<td>
            .400
           </td>
-          <td>
+<td>
            .708
           </td>
-          <td>
+<td>
            95
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-02-28.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-02-28.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [-0.4, 1.1, 2.7, 0.0, 1.9, 4.2, 0.4, -0.1, 0.3];
             const teamsByYear = ["NYM", "NYM", "NYM", "NYM", "CLE", "CLE", "2TM", "3TM", "2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["WSN", "NYM", "CLE", "CIN", "2TM", "NYY", "LAD", "TBR"], "years": ["2018", "2020", "2017", "2019", "2024", "2025", "2021", "2022", "2023"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Amed Rosario", "hints": ["Ranked as the number one overall prospect by Baseball Prospectus before the 2017 season.", "Led the major leagues in triples in both 2018 and 2022.", "Was the main player acquired by Cleveland in the trade that sent Francisco Lindor to the New York Mets."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-05.html
+++ b/2026-03-05.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-05" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Duke Ellis.">
   <title>
    Duke Ellis Answer - March 05, 2026 | Name That Yankee
   </title>

--- a/2026-03-05.html
+++ b/2026-03-05.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-05" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Duke Ellis, the featured New York Yankee for the 2026-03-05 trivia puzzle." name="description"/>
+
+<title>
    Duke Ellis Answer - March 05, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 05, 2026: Duke Ellis. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - March 05, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-05.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 05, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-05.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - March 05, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 05, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-05.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,230 +42,230 @@
   "datePublished": "2026-03-05"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 05, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Duke Ellis" src="images/answer-2026-03-05.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Duke Ellis" src="images/answer-2026-03-05.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Duke Ellis
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Son of former major-league pitcher Robert Ellis.
         </li>
-        <li>
+<li>
          Signed as an undrafted free agent following the shortened five-round 2020 amateur draft.
         </li>
-        <li>
+<li>
          Recorded four stolen bases without a single plate appearance during the first eight games of a major-league career.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Duke Ellis?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After going unselected in the shortened five-round 2020 draft, Ellis signed a minor-league contract with the Chicago White Sox. He developed in the minor leagues primarily as a speed and defense specialist, culminating in a June 2024 major-league debut. During his rookie 2024 season, multiple waiver claims led him to spend time in the White Sox, Mets, Mariners, and Yankees organizations.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After going unselected in the shortened five-round 2020 draft, Ellis signed a minor-league contract with the Chicago White Sox. He developed in the minor leagues primarily as a speed and defense specialist, culminating in a June 2024 major-league debut. During his rookie 2024 season, multiple waiver claims led him to spend time in the White Sox, Mets, Mariners, and Yankees organizations.">
            How did Duke Ellis's journey to the major leagues unfold after going unselected in the 2020 draft?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Claimed off waivers from the Seattle Mariners in late August 2024, Ellis was called up to the Yankees in September to serve primarily as a pinch-running specialist. He appeared in three games for New York, scoring one run without recording a plate appearance. This brief stint provided manager Aaron Boone with elite late-inning speed off the bench during the team's American League East pennant chase.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Claimed off waivers from the Seattle Mariners in late August 2024, Ellis was called up to the Yankees in September to serve primarily as a pinch-running specialist. He appeared in three games for New York, scoring one run without recording a plate appearance. This brief stint provided manager Aaron Boone with elite late-inning speed off the bench during the team's American League East pennant chase.">
            What specific role did Ellis fill during his brief stint with the New York Yankees in September 2024?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Ellis has a direct lineage to the major leagues through his father, Robert Ellis, who was a professional pitcher. Robert pitched in the big leagues for parts of four seasons between 1996 and 2003, taking the mound for the Angels, Diamondbacks, Dodgers, and Rangers. Growing up around the game gave Duke a firsthand look at the demands of professional baseball long before he reached the majors himself.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Ellis has a direct lineage to the major leagues through his father, Robert Ellis, who was a professional pitcher. Robert pitched in the big leagues for parts of four seasons between 1996 and 2003, taking the mound for the Angels, Diamondbacks, Dodgers, and Rangers. Growing up around the game gave Duke a firsthand look at the demands of professional baseball long before he reached the majors himself.">
            What is Ellis's family connection to professional baseball?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            -0.1
           </td>
-          <td>
+<td>
            5
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            .200
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            0
           </td>
-          <td>
+<td>
            5
           </td>
-          <td>
+<td>
            .200
           </td>
-          <td>
+<td>
            .200
           </td>
-          <td>
+<td>
            .400
           </td>
-          <td>
+<td>
            15
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-05.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2024"];
             const warData = [-0.1];
             const teamsByYear = ["2TM"];
@@ -385,18 +386,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CHW"], "years": ["2024"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Duke Ellis", "hints": ["Son of former major-league pitcher Robert Ellis.", "Signed as an undrafted free agent following the shortened five-round 2020 amateur draft.", "Recorded four stolen bases without a single plate appearance during the first eight games of a major-league career."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -424,15 +425,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -443,11 +444,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-06.html
+++ b/2026-03-06.html
@@ -1,25 +1,26 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-06" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-06" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul Blackburn, the featured New York Yankee for the 2026-03-06 trivia puzzle." name="description"/>
+
+<title>
    Paul Blackburn Answer - March 06, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 06, 2026: Paul Blackburn. See their stats and highlights!" name="description"/>
-  <meta content="Name That Yankee - March 06, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-06.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 06, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-06.webp" name="twitter:image"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="images/favicon.ico" rel="shortcut icon" type="image/x-icon"/>
+
+<meta content="Name That Yankee - March 06, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-06.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 06, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-06.webp" name="twitter:image"/>
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -41,218 +42,218 @@
   "datePublished": "2026-03-06"
 }
   </script>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+<link href="manifest.json" rel="manifest"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 06, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul Blackburn" src="images/answer-2026-03-06.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul Blackburn" src="images/answer-2026-03-06.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul Blackburn
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Named an American League All-Star for the first time in 2022.
         </li>
-        <li>
+<li>
          Acquired by the Oakland Athletics in a 2016 trade with the Seattle Mariners for Danny Valencia.
         </li>
-        <li>
+<li>
          Grew up in the Bay Area and attended Heritage High School in Brentwood, California.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Paul Blackburn?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After being designated for assignment by the A's in early 2021, he cleared waivers and accepted an assignment to Triple-A. There, he refined his pitching arsenal, most notably adding a cutter and improving his curveball's effectiveness. This led to a strong return to the majors and culminated in a breakout 2022 season where he posted a 1.70 ERA through his first 12 starts, earning an All-Star selection.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After being designated for assignment by the A's in early 2021, he cleared waivers and accepted an assignment to Triple-A. There, he refined his pitching arsenal, most notably adding a cutter and improving his curveball's effectiveness. This led to a strong return to the majors and culminated in a breakout 2022 season where he posted a 1.70 ERA through his first 12 starts, earning an All-Star selection.">
            How did Paul Blackburn go from being designated for assignment to becoming an All-Star?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Blackburn has generally struggled in his appearances against the New York Yankees. Through the 2023 season, he has made five career starts against them, posting an 0-2 record with a 7.52 ERA. In those 20.1 innings pitched, he has allowed 17 earned runs.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Blackburn has generally struggled in his appearances against the New York Yankees. Through the 2023 season, he has made five career starts against them, posting an 0-2 record with a 7.52 ERA. In those 20.1 innings pitched, he has allowed 17 earned runs.">
            How has Paul Blackburn performed against the Yankees in his career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="&quot;Blackburn's Battalion&quot; is a dedicated cheering section at the Oakland Coliseum organized by his family and friends from his nearby hometown of Antioch. The group often wears custom t-shirts and vocally supports him during his home starts. It's a prominent example of his strong local ties to the Bay Area community.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="&quot;Blackburn's Battalion&quot; is a dedicated cheering section at the Oakland Coliseum organized by his family and friends from his nearby hometown of Antioch. The group often wears custom t-shirts and vocally supports him during his home starts. It's a prominent example of his strong local ties to the Bay Area community.">
            What is the story behind the "Blackburn's Battalion" cheering section?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            2.5
           </td>
-          <td>
+<td>
            22
           </td>
-          <td>
+<td>
            31
           </td>
-          <td>
+<td>
            4.97
           </td>
-          <td>
+<td>
            101
           </td>
-          <td>
+<td>
            86
           </td>
-          <td>
+<td>
            1
           </td>
-          <td>
+<td>
            467.1
           </td>
-          <td>
+<td>
            363
           </td>
-          <td>
+<td>
            1.414
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-06.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-06.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [1.5, -0.6, -0.5, -0.3, -0.2, 1.3, 1.5, 0.5, -0.5];
             const teamsByYear = ["OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "2TM", "2TM"];
@@ -373,18 +374,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYM", "OAK", "NYY"], "years": ["2022", "2019", "2018", "2017", "2025", "2020", "2021", "2023", "2024"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul Blackburn", "hints": ["Named an American League All-Star for the first time in 2022.", "Acquired by the Oakland Athletics in a 2016 trade with the Seattle Mariners for Danny Valencia.", "Grew up in the Bay Area and attended Heritage High School in Brentwood, California."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -412,15 +413,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -431,11 +432,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-06.html
+++ b/2026-03-06.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-06" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul Blackburn.">
   <title>
    Paul Blackburn Answer - March 06, 2026 | Name That Yankee
   </title>

--- a/2026-03-11.html
+++ b/2026-03-11.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-11" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jos\u00e9 Caballero.">
   <title>
    José Caballero Answer - March 11, 2026 | Name That Yankee
   </title>

--- a/2026-03-11.html
+++ b/2026-03-11.html
@@ -1,29 +1,30 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-11" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-11" rel="canonical"/><meta content="Discover the career highlights and statistics for José Caballero, the featured New York Yankee for the 2026-03-11 trivia puzzle." name="description"/>
+
+<title>
    José Caballero Answer - March 11, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <!-- Meta tags for better social sharing -->
-  <meta content="Name That Yankee - March 11, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-11.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 11, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-11.webp" name="twitter:image"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 11, 2026: José Caballero. See their stats and highlights!" name="description"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 11, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-11.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 11, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-11.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -45,227 +46,227 @@
   "datePublished": "2026-03-11"
 }
   </script>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 11, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of José Caballero" src="images/answer-2026-03-11.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of José Caballero" src="images/answer-2026-03-11.webp"/>
+</div>
+<div class="player-info">
+<h2>
         José Caballero
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Became the first Panamanian-born player to debut for the Seattle Mariners in 2023.
         </li>
-        <li>
+<li>
          Led all American League rookies in stolen bases during the 2023 season.
         </li>
-        <li>
+<li>
          Recorded a career-high 44 stolen bases during the 2024 campaign with the Tampa Bay Rays.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about José Caballero?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Originally signed by the Arizona Diamondbacks as an international free agent, the infielder was traded to the Seattle Mariners in 2022. After establishing himself as a speed threat and defensive utility player in Seattle, a 2024 trade sent him to the Tampa Bay Rays. He has since become a consistent presence in the middle infield, known primarily for his aggressive base-running and defensive flexibility.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Originally signed by the Arizona Diamondbacks as an international free agent, the infielder was traded to the Seattle Mariners in 2022. After establishing himself as a speed threat and defensive utility player in Seattle, a 2024 trade sent him to the Tampa Bay Rays. He has since become a consistent presence in the middle infield, known primarily for his aggressive base-running and defensive flexibility.">
            How would you summarize the professional trajectory of this versatile infielder?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="This player has never been a member of the New York Yankees organization. Throughout his career, he has faced the Yankees as an opponent, most notably during his tenure with the Tampa Bay Rays in the American League East. He has not recorded any postseason appearances against the franchise to date.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="This player has never been a member of the New York Yankees organization. Throughout his career, he has faced the Yankees as an opponent, most notably during his tenure with the Tampa Bay Rays in the American League East. He has not recorded any postseason appearances against the franchise to date.">
            Has this player ever played for the New York Yankees or recorded notable statistics against them?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The infielder is known for his high-energy, 'pesky' style of play that often irritates opposing pitchers and catchers. He frequently engages in gamesmanship on the basepaths, utilizing quick movements and constant pressure to disrupt defensive rhythm. This aggressive approach earned him a reputation as one of the most disruptive base runners in the league during his breakout 2024 season.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The infielder is known for his high-energy, 'pesky' style of play that often irritates opposing pitchers and catchers. He frequently engages in gamesmanship on the basepaths, utilizing quick movements and constant pressure to disrupt defensive rhythm. This aggressive approach earned him a reputation as one of the most disruptive base runners in the league during his breakout 2024 season.">
            What is a unique or lesser-known aspect of this player's background or personality?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            6.8
           </td>
-          <td>
+<td>
            986
           </td>
-          <td>
+<td>
            225
           </td>
-          <td>
+<td>
            18
           </td>
-          <td>
+<td>
            .228
           </td>
-          <td>
+<td>
            142
           </td>
-          <td>
+<td>
            106
           </td>
-          <td>
+<td>
            119
           </td>
-          <td>
+<td>
            .316
           </td>
-          <td>
+<td>
            .341
           </td>
-          <td>
+<td>
            .657
           </td>
-          <td>
+<td>
            88
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-11.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-11.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2023", "2024", "2025"];
             const warData = [2.5, 1.6, 2.9];
             const teamsByYear = ["SEA", "TBR", "2TM"];
@@ -386,18 +387,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["TBR", "NYY", "SEA"], "years": ["2025", "2023", "2024"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Jos\u00e9 Caballero", "hints": ["Became the first Panamanian-born player to debut for the Seattle Mariners in 2023.", "Led all American League rookies in stolen bases during the 2023 season.", "Recorded a career-high 44 stolen bases during the 2024 campaign with the Tampa Bay Rays."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -425,15 +426,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -444,11 +445,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-15.html
+++ b/2026-03-15.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-15" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Trent Grisham.">
   <title>
    Trent Grisham Answer - March 15, 2026 | Name That Yankee
   </title>

--- a/2026-03-15.html
+++ b/2026-03-15.html
@@ -1,29 +1,30 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-15" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-15" rel="canonical"/><meta content="Discover the career highlights and statistics for Trent Grisham, the featured New York Yankee for the 2026-03-15 trivia puzzle." name="description"/>
+
+<title>
    Trent Grisham Answer - March 15, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <!-- Meta tags for better social sharing -->
-  <meta content="Name That Yankee - March 15, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-15.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 15, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-15.webp" name="twitter:image"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 15, 2026: Trent Grisham. See their stats and highlights!" name="description"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 15, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-15.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 15, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-15.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -45,227 +46,227 @@
   "datePublished": "2026-03-15"
 }
   </script>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 15, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Trent Grisham" src="images/answer-2026-03-15.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Trent Grisham" src="images/answer-2026-03-15.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Trent Grisham "Grish"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Won a National League Gold Glove Award as a center fielder in 2020.
         </li>
-        <li>
+<li>
          Hit a go-ahead home run against Clayton Kershaw in the 2020 National League Wild Card Series.
         </li>
-        <li>
+<li>
          Selected in the first round of the 2015 MLB Draft by the Milwaukee Brewers.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Trent Grisham?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="After debuting with the Brewers in 2019, the outfielder became a defensive staple for the Padres, earning a Gold Glove in 2020. Known for a high walk rate and power-speed combination, the player was traded to the New York Yankees in December 2023 as part of the Juan Soto deal. The career has been defined by elite defensive metrics and timely postseason power.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After debuting with the Brewers in 2019, the outfielder became a defensive staple for the Padres, earning a Gold Glove in 2020. Known for a high walk rate and power-speed combination, the player was traded to the New York Yankees in December 2023 as part of the Juan Soto deal. The career has been defined by elite defensive metrics and timely postseason power.">
            How would you summarize the career trajectory of this outfielder?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="During the 2024 season, the outfielder provided a crucial spark in a game against the Boston Red Sox by hitting a go-ahead three-run home run in the sixth inning. This performance helped secure a victory in a high-stakes rivalry matchup. The player has primarily served as a versatile defensive replacement and depth option for the Yankees' outfield.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During the 2024 season, the outfielder provided a crucial spark in a game against the Boston Red Sox by hitting a go-ahead three-run home run in the sixth inning. This performance helped secure a victory in a high-stakes rivalry matchup. The player has primarily served as a versatile defensive replacement and depth option for the Yankees' outfield.">
            What has been a standout moment for this player since joining the New York Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The player was originally drafted and played in the minor leagues under the name Trent Clark. In 2018, the decision was made to switch to the surname Grisham, which is the player's mother's maiden name. This change was intended to honor the family member who played the most significant role in the player's upbringing.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The player was originally drafted and played in the minor leagues under the name Trent Clark. In 2018, the decision was made to switch to the surname Grisham, which is the player's mother's maiden name. This change was intended to honor the family member who played the most significant role in the player's upbringing.">
            Is there a notable story regarding the player's name change early in a professional career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            14.6
           </td>
-          <td>
+<td>
            2426
           </td>
-          <td>
+<td>
            528
           </td>
-          <td>
+<td>
            104
           </td>
-          <td>
+<td>
            .218
           </td>
-          <td>
+<td>
            360
           </td>
-          <td>
+<td>
            320
           </td>
-          <td>
+<td>
            50
           </td>
-          <td>
+<td>
            .321
           </td>
-          <td>
+<td>
            .400
           </td>
-          <td>
+<td>
            .720
           </td>
-          <td>
+<td>
            101
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-15.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-15.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [0.6, 2.5, 3.1, 2.7, 1.8, 0.4, 3.5];
             const teamsByYear = ["MIL", "SDP", "SDP", "SDP", "SDP", "NYY", "NYY"];
@@ -386,18 +387,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "MIL", "SDP"], "years": ["2024", "2022", "2020", "2021", "2023", "2025", "2019"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Trent Grisham", "hints": ["Won a National League Gold Glove Award as a center fielder in 2020.", "Hit a go-ahead home run against Clayton Kershaw in the 2020 National League Wild Card Series.", "Selected in the first round of the 2015 MLB Draft by the Milwaukee Brewers."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -425,15 +426,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -444,11 +445,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-18.html
+++ b/2026-03-18.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-18" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Fernando Cruz.">
   <title>
    Fernando Cruz Answer - March 18, 2026 | Name That Yankee
   </title>

--- a/2026-03-18.html
+++ b/2026-03-18.html
@@ -1,29 +1,30 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-18" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-18" rel="canonical"/><meta content="Discover the career highlights and statistics for Fernando Cruz, the featured New York Yankee for the 2026-03-18 trivia puzzle." name="description"/>
+
+<title>
    Fernando Cruz Answer - March 18, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <!-- Meta tags for better social sharing -->
-  <meta content="Name That Yankee - March 18, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-18.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 18, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-18.webp" name="twitter:image"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 18, 2026: Fernando Cruz. See their stats and highlights!" name="description"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 18, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-18.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 18, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-18.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -45,215 +46,215 @@
   "datePublished": "2026-03-18"
 }
   </script>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 18, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Fernando Cruz" src="images/answer-2026-03-18.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Fernando Cruz" src="images/answer-2026-03-18.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Fernando Cruz
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Made a Major League Baseball debut at age 32 after spending over a decade in the minor leagues and independent ball.
         </li>
-        <li>
+<li>
          Set a Cincinnati Reds franchise record for the most strikeouts by a relief pitcher in a single season during 2024.
         </li>
-        <li>
+<li>
          Played as an infielder for several years in the minor leagues before successfully transitioning to a full-time pitching role.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Fernando Cruz?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="The career path is defined by extreme perseverance, spanning over 15 years of professional baseball. After being drafted as an infielder in 2007, the transition to pitching occurred in 2015, eventually leading to a big league debut with the Cincinnati Reds in 2022. This journey highlights a rare ability to reinvent oneself and maintain high-level performance well into the player's thirties.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The career path is defined by extreme perseverance, spanning over 15 years of professional baseball. After being drafted as an infielder in 2007, the transition to pitching occurred in 2015, eventually leading to a big league debut with the Cincinnati Reds in 2022. This journey highlights a rare ability to reinvent oneself and maintain high-level performance well into the player's thirties.">
            How would you describe the trajectory of this player's professional career?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="There is no record of this player appearing in a game for the New York Yankees or participating in their postseason history. The professional career has been spent primarily within the organizations of the Kansas City Royals, Chicago Cubs, and Cincinnati Reds. Consequently, there are no Yankees-specific statistics or moments associated with this individual.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="There is no record of this player appearing in a game for the New York Yankees or participating in their postseason history. The professional career has been spent primarily within the organizations of the Kansas City Royals, Chicago Cubs, and Cincinnati Reds. Consequently, there are no Yankees-specific statistics or moments associated with this individual.">
            Has this player ever played for the New York Yankees or contributed to their postseason history?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Before reaching the major leagues, the pitcher spent significant time playing in the Puerto Rican Winter League and independent leagues like the Atlantic League. This period of uncertainty included working various jobs to support a family while continuing to pursue a professional baseball dream. The eventual success in the majors serves as a notable example of longevity and dedication in the face of long odds.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Before reaching the major leagues, the pitcher spent significant time playing in the Puerto Rican Winter League and independent leagues like the Atlantic League. This period of uncertainty included working various jobs to support a family while continuing to pursue a professional baseball dream. The eventual success in the majors serves as a notable example of longevity and dedication in the face of long odds.">
            What is a unique or lesser-known aspect of this player's background?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            W
           </th>
-          <th>
+<th>
            L
           </th>
-          <th>
+<th>
            ERA
           </th>
-          <th>
+<th>
            G
           </th>
-          <th>
+<th>
            GS
           </th>
-          <th>
+<th>
            SV
           </th>
-          <th>
+<th>
            IP
           </th>
-          <th>
+<th>
            SO
           </th>
-          <th>
+<th>
            WHIP
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            1.7
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            15
           </td>
-          <td>
+<td>
            4.28
           </td>
-          <td>
+<td>
            190
           </td>
-          <td>
+<td>
            7
           </td>
-          <td>
+<td>
            2
           </td>
-          <td>
+<td>
            195.1
           </td>
-          <td>
+<td>
            300
           </td>
-          <td>
+<td>
            1.249
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-18.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-18.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2022", "2023", "2024", "2025"];
             const warData = [0.8, 0.3, 0.3, 0.3];
             const teamsByYear = ["CIN", "CIN", "CIN", "NYY"];
@@ -374,18 +375,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["NYY", "CIN"], "years": ["2022", "2025", "2023", "2024"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Fernando Cruz", "hints": ["Made a Major League Baseball debut at age 32 after spending over a decade in the minor leagues and independent ball.", "Set a Cincinnati Reds franchise record for the most strikeouts by a relief pitcher in a single season during 2024.", "Played as an infielder for several years in the minor leagues before successfully transitioning to a full-time pitching role."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -413,15 +414,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -432,11 +433,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-19.html
+++ b/2026-03-19.html
@@ -1,29 +1,30 @@
 <!DOCTYPE html>
+
 <html lang="en">
- <head>
-  <meta charset="utf-8"/>
-  <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
-  <link href="https://namethatyankeequiz.com/2026-03-19" rel="canonical"/>
-  <title>
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-19" rel="canonical"/><meta content="Discover the career highlights and statistics for Paul Goldschmidt, the featured New York Yankee for the 2026-03-19 trivia puzzle." name="description"/>
+
+<title>
    Paul Goldschmidt Answer - March 19, 2026 | Name That Yankee
   </title>
-  <link href="style.css" rel="stylesheet"/>
-  <link href="manifest.json" rel="manifest"/>
-  <link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
-  <link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
-  <!-- Meta tags for better social sharing -->
-  <meta content="Name That Yankee - March 19, 2026" property="og:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
-  <meta content="website" property="og:type"/>
-  <meta content="Name That Yankee" property="og:site_name"/>
-  <meta content="images/clue-2026-03-19.webp" property="og:image"/>
-  <meta content="summary_large_image" name="twitter:card"/>
-  <meta content="Name That Yankee - March 19, 2026" name="twitter:title"/>
-  <meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
-  <meta content="images/clue-2026-03-19.webp" name="twitter:image"/>
-  <meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
-  <meta content="Revealing the answer for the New York Yankees trivia puzzle on March 19, 2026: Paul Goldschmidt. See their stats and highlights!" name="description"/>
-  <script type="application/ld+json">
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 19, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-19.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 19, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-19.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+
+<script type="application/ld+json">
    {
   "@context": "https://schema.org",
   "@type": "Article",
@@ -45,227 +46,227 @@
   "datePublished": "2026-03-19"
 }
   </script>
- </head>
- <body>
-  <header>
-   <div class="header-content">
-    <h1>
+</head>
+<body>
+<header>
+<div class="header-content">
+<h1>
      The answer for March 19, 2026 is...
     </h1>
-   </div>
-   <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <div id="score-display">
+<div id="score-display">
      Your Score:
      <span id="total-score">
       0
      </span>
-     <svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="6 9 12 15 18 9">
-      </polyline>
-     </svg>
-     <div id="score-breakdown-container" style="display: none;">
-      <div class="breakdown-header">
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+<polyline points="6 9 12 15 18 9">
+</polyline>
+</svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">
        Score Breakdown
       </div>
-      <table>
-       <thead>
-        <tr>
-         <th>
+<table>
+<thead>
+<tr>
+<th>
           Clue
          </th>
-         <th>
+<th>
           Points
          </th>
-         <th>
+<th>
           Count
          </th>
-        </tr>
-       </thead>
-       <tbody id="breakdown-body">
-       </tbody>
-      </table>
-     </div>
-    </div>
-   </div>
-  </header>
-  <main>
-   <a class="back-link" href="index.html">
+</tr>
+</thead>
+<tbody id="breakdown-body">
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">
     ← Back to All Questions
    </a>
-   <div class="detail-layout">
-    <div class="left-column">
-     <div class="player-profile">
-      <div class="player-photo">
-       <img alt="Photo of Paul Goldschmidt" src="images/answer-2026-03-19.webp"/>
-      </div>
-      <div class="player-info">
-       <h2>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Paul Goldschmidt" src="images/answer-2026-03-19.webp"/>
+</div>
+<div class="player-info">
+<h2>
         Paul Goldschmidt "Goldy"
        </h2>
-       <div class="facts-header">
-        <h3>
+<div class="facts-header">
+<h3>
          Career Highlights &amp; Facts
         </h3>
-        <p class="disclaimer">
+<p class="disclaimer">
          (Facts are AI-generated and may require verification)
         </p>
-       </div>
-       <ul>
-        <li>
+</div>
+<ul>
+<li>
          Earned the 2022 National League Most Valuable Player award.
         </li>
-        <li>
+<li>
          Selected to seven All-Star games across stints with three different franchises.
         </li>
-        <li>
+<li>
          Won four Gold Glove Awards for defensive excellence at first base.
         </li>
-       </ul>
-       <div class="followup-section" id="followup-section">
-        <h3>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>
          Would you like to find out more about Paul Goldschmidt?
         </h3>
-        <div class="followup-buttons">
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Starting as an eighth-round draft pick, the slugger developed into one of the most consistent offensive threats in baseball history. Over his career, he has surpassed 300 home runs and 1,000 RBIs while maintaining a high career on-base percentage. His ability to combine power with elite defensive play has made him a perennial MVP candidate for over a decade.">
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Starting as an eighth-round draft pick, the slugger developed into one of the most consistent offensive threats in baseball history. Over his career, he has surpassed 300 home runs and 1,000 RBIs while maintaining a high career on-base percentage. His ability to combine power with elite defensive play has made him a perennial MVP candidate for over a decade.">
            How would you summarize the overall career trajectory of this first baseman?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Because he has spent his entire career in the National League, his opportunities to face the Yankees have been limited to Interleague play. In his limited career plate appearances against New York, he has maintained a respectable OPS, including a notable multi-hit performance during a 2023 series at Yankee Stadium. He has never played for the Yankees, so his postseason history against them is non-existent.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Because he has spent his entire career in the National League, his opportunities to face the Yankees have been limited to Interleague play. In his limited career plate appearances against New York, he has maintained a respectable OPS, including a notable multi-hit performance during a 2023 series at Yankee Stadium. He has never played for the Yankees, so his postseason history against them is non-existent.">
            What are some notable moments or statistics from this player's history against the New York Yankees?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-         <div class="followup-item">
-          <button class="followup-btn" data-answer="Known for a quiet and humble demeanor, he famously completed his college degree in management while already playing in the major leagues. He is also recognized for his intense focus on preparation and his reputation as a clubhouse leader who avoids the spotlight. His disciplined approach to the game is often cited by teammates as a primary reason for his longevity.">
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Known for a quiet and humble demeanor, he famously completed his college degree in management while already playing in the major leagues. He is also recognized for his intense focus on preparation and his reputation as a clubhouse leader who avoids the spotlight. His disciplined approach to the game is often cited by teammates as a primary reason for his longevity.">
            Is there anything unique about this player's background or personality off the field?
           </button>
-          <div class="followup-answer" style="display:none;">
-          </div>
-         </div>
-        </div>
-       </div>
-      </div>
-     </div>
-     <div class="stats-table-container">
-      <h3>
+<div class="followup-answer" style="display:none;">
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>
        Career Totals
       </h3>
-      <div class="table-wrapper">
-       <table>
-        <thead>
-         <tr>
-          <th>
+<div class="table-wrapper">
+<table>
+<thead>
+<tr>
+<th>
            WAR
           </th>
-          <th>
+<th>
            AB
           </th>
-          <th>
+<th>
            H
           </th>
-          <th>
+<th>
            HR
           </th>
-          <th>
+<th>
            BA
           </th>
-          <th>
+<th>
            R
           </th>
-          <th>
+<th>
            RBI
           </th>
-          <th>
+<th>
            SB
           </th>
-          <th>
+<th>
            OBP
           </th>
-          <th>
+<th>
            SLG
           </th>
-          <th>
+<th>
            OPS
           </th>
-          <th>
+<th>
            OPS+
           </th>
-         </tr>
-        </thead>
-        <tbody>
-         <tr>
-          <td>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>
            63.8
           </td>
-          <td>
+<td>
            7608
           </td>
-          <td>
+<td>
            2190
           </td>
-          <td>
+<td>
            372
           </td>
-          <td>
+<td>
            .288
           </td>
-          <td>
+<td>
            1280
           </td>
-          <td>
+<td>
            1232
           </td>
-          <td>
+<td>
            174
           </td>
-          <td>
+<td>
            .378
           </td>
-          <td>
+<td>
            .504
           </td>
-          <td>
+<td>
            .882
           </td>
-          <td>
+<td>
            137
           </td>
-         </tr>
-        </tbody>
-       </table>
-      </div>
-      <p class="citation">
+</tr>
+</tbody>
+</table>
+</div>
+<p class="citation">
        Statistics via Baseball-Reference.com
       </p>
-     </div>
-    </div>
-    <div class="right-column">
-     <div class="original-card">
-      <h3>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>
        The Original Clue
       </h3>
-      <img alt="Original trivia card" src="images/clue-2026-03-19.webp"/>
-     </div>
-     <div class="chart-container">
-      <h3>
+<img alt="Original trivia card" src="images/clue-2026-03-19.webp"/>
+</div>
+<div class="chart-container">
+<h3>
        Career Arc by WAR
       </h3>
-      <div class="chart-wrapper">
-       <canvas id="careerArcChart">
-       </canvas>
-      </div>
-     </div>
-     <script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
-     </script>
-     <script>
+<div class="chart-wrapper">
+<canvas id="careerArcChart">
+</canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1">
+</script>
+<script>
       const years = ["2011", "2012", "2013", "2014", "2015", "2016", "2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [0.4, 3.4, 6.3, 4.7, 8.3, 4.9, 6.1, 5.8, 2.6, 2.0, 5.9, 7.7, 3.3, 1.3, 1.2];
             const teamsByYear = ["ARI", "ARI", "ARI", "ARI", "ARI", "ARI", "ARI", "ARI", "STL", "STL", "STL", "STL", "STL", "STL", "NYY"];
@@ -386,18 +387,18 @@
                 }
             });
      </script>
-    </div>
-   </div>
-   <div id="search-data" style="display:none;">
+</div>
+</div>
+<div id="search-data" style="display:none;">
     {"teams": ["STL", "NYY", "ARI"], "years": ["2016", "2017", "2021", "2013", "2015", "2018", "2024", "2025", "2014", "2022", "2023", "2020", "2011", "2019", "2012"]}
    </div>
-   <div id="quiz-data" style="display:none;">
+<div id="quiz-data" style="display:none;">
     {"answer": "Paul Goldschmidt", "hints": ["Earned the 2022 National League Most Valuable Player award.", "Selected to seven All-Star games across stints with three different franchises.", "Won four Gold Glove Awards for defensive excellence at first base."]}
    </div>
-  </main>
-  <script src="js/detail.js" type="module">
-  </script>
-  <script>
+</main>
+<script src="js/detail.js" type="module">
+</script>
+<script>
    document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -425,15 +426,15 @@
         });
     });
   </script>
-  <footer>
-   <p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
-   <p id="last-updated">
+<p id="last-updated">
     Last Updated: 20-Mar-2026
    </p>
-   <p class="copyright">
-    <a href="https://namethatyankeequiz.com">
+<p class="copyright">
+<a href="https://namethatyankeequiz.com">
      Name That Yankee Quiz
     </a>
     © 2026 by
@@ -444,11 +445,11 @@
     <a href="https://creativecommons.org/licenses/by-nc-sa/4.0/">
      CC BY-NC-SA 4.0
     </a>
-    <img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-    <img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
-   </p>
-  </footer>
- </body>
+<img alt="CC" src="https://mirrors.creativecommons.org/presskit/icons/cc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="BY" src="https://mirrors.creativecommons.org/presskit/icons/by.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="NC" src="https://mirrors.creativecommons.org/presskit/icons/nc.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+<img alt="SA" src="https://mirrors.creativecommons.org/presskit/icons/sa.svg" style="max-width: 1em;max-height:1em;margin-left: .2em;"/>
+</p>
+</footer>
+</body>
 </html>

--- a/2026-03-19.html
+++ b/2026-03-19.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8"/>
   <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
   <link href="https://namethatyankeequiz.com/2026-03-19" rel="canonical"/>
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Paul Goldschmidt.">
   <title>
    Paul Goldschmidt Answer - March 19, 2026 | Name That Yankee
   </title>

--- a/2026-03-22.html
+++ b/2026-03-22.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-03-22 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-03-22">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Aaron Boone.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - March 22, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-03-22.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - March 22, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-03-22.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-22" rel="canonical"/><meta content="Discover the career highlights and statistics for Aaron Boone, the featured New York Yankee for the 2026-03-22 trivia puzzle." name="description"/>
+<title>Answer for 2026-03-22 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 22, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-22.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 22, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-22.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for March 22, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for March 22, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-03-22.webp" alt="Photo of Aaron Boone">
-                    </div>
-                    <div class="player-info">
-                        <h2>Aaron Boone</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Selected as an American League All-Star during the 2003 season.</li>
-                        <li>Part of a three-generation family lineage of Major League Baseball players.</li>
-                        <li>Hit a walk-off home run in the 11th inning of the 2003 American League Championship Series Game 7.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Aaron Boone?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The career spanned 12 seasons across four different teams, primarily as a third baseman. While primarily known for defensive versatility and clutch hitting, the career included 126 home runs and 555 runs batted in. After retiring as a player in 2009, the transition to coaching eventually led to a long-term managerial role.">How would you summarize the overall professional trajectory of this player?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The walk-off home run off Tim Wakefield ended a tense Game 7 against the Boston Red Sox, securing the American League pennant for the Yankees. This moment is widely considered one of the most iconic in franchise history, as it prevented a Red Sox comeback and extended the Yankees&#x27; dominance in the rivalry at the time. It remains the defining highlight of the player&#x27;s tenure in New York.">What is the significance of the 2003 ALCS home run for the Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Following retirement, a successful career in broadcasting began as an analyst for ESPN, where appearances included the Sunday Night Baseball booth. This media experience provided a platform for deep analytical engagement with the sport before returning to the field. In 2018, the transition to the dugout was completed by becoming the manager of the New York Yankees.">What did the career path look like after retiring from active play?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>13.6</td><td>3871</td><td>1017</td><td>126</td><td>.263</td><td>519</td><td>555</td><td>107</td><td>.326</td><td>.425</td><td>.751</td><td>94</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-03-22.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Aaron Boone" src="images/answer-2026-03-22.webp"/>
+</div>
+<div class="player-info">
+<h2>Aaron Boone</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Selected as an American League All-Star during the 2003 season.</li>
+<li>Part of a three-generation family lineage of Major League Baseball players.</li>
+<li>Hit a walk-off home run in the 11th inning of the 2003 American League Championship Series Game 7.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Aaron Boone?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The career spanned 12 seasons across four different teams, primarily as a third baseman. While primarily known for defensive versatility and clutch hitting, the career included 126 home runs and 555 runs batted in. After retiring as a player in 2009, the transition to coaching eventually led to a long-term managerial role.">How would you summarize the overall professional trajectory of this player?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The walk-off home run off Tim Wakefield ended a tense Game 7 against the Boston Red Sox, securing the American League pennant for the Yankees. This moment is widely considered one of the most iconic in franchise history, as it prevented a Red Sox comeback and extended the Yankees' dominance in the rivalry at the time. It remains the defining highlight of the player's tenure in New York.">What is the significance of the 2003 ALCS home run for the Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Following retirement, a successful career in broadcasting began as an analyst for ESPN, where appearances included the Sunday Night Baseball booth. This media experience provided a platform for deep analytical engagement with the sport before returning to the field. In 2018, the transition to the dugout was completed by becoming the manager of the New York Yankees.">What did the career path look like after retiring from active play?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>13.6</td><td>3871</td><td>1017</td><td>126</td><td>.263</td><td>519</td><td>555</td><td>107</td><td>.326</td><td>.425</td><td>.751</td><td>94</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-03-22.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1997", "1998", "1999", "2000", "2001", "2002", "2003", "2005", "2006", "2007", "2008", "2009"];
             const warData = [-0.6, 0.6, 2.3, 2.0, 1.7, 3.2, 4.1, 1.5, -0.7, 0.4, -0.6, -0.3];
             const teamsByYear = ["CIN", "CIN", "CIN", "CIN", "CIN", "CIN", "2TM", "CLE", "CLE", "FLA", "WSN", "HOU"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["WSN", "FLA", "HOU", "CIN", "CLE", "NYY"], "years": ["2002", "2009", "2003", "2007", "2001", "1997", "2005", "1998", "2000", "2008", "1999", "2006"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Aaron Boone", "hints": ["Selected as an American League All-Star during the 2003 season.", "Part of a three-generation family lineage of Major League Baseball players.", "Hit a walk-off home run in the 11th inning of the 2003 American League Championship Series Game 7."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["WSN", "FLA", "HOU", "CIN", "CLE", "NYY"], "years": ["2002", "2009", "2003", "2007", "2001", "1997", "2005", "1998", "2000", "2008", "1999", "2006"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Aaron Boone", "hints": ["Selected as an American League All-Star during the 2003 season.", "Part of a three-generation family lineage of Major League Baseball players.", "Hit a walk-off home run in the 11th inning of the 2003 American League Championship Series Game 7."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 22-Mar-2026</p>
-    </footer>    
+<p>Last Updated: 22-Mar-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-03-27.html
+++ b/2026-03-27.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-03-27 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-03-27">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Joe DiMaggio.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - March 27, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-03-27.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - March 27, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-03-27.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-27" rel="canonical"/><meta content="Discover the career highlights and statistics for Joe DiMaggio &quot;Joltin' Joe, The Yankee Clipper&quot;, the featured New York Yankee for the 2026-03-27 trivia puzzle." name="description"/>
+<title>Answer for 2026-03-27 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 27, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-27.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 27, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-27.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for March 27, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for March 27, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-03-27.webp" alt="Photo of Joe DiMaggio">
-                    </div>
-                    <div class="player-info">
-                        <h2>Joe DiMaggio "Joltin' Joe, The Yankee Clipper"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Maintained a record 56-game hitting streak during the 1941 season.</li>
-                        <li>Earned three American League Most Valuable Player awards throughout a 13-season career.</li>
-                        <li>Secured nine World Series championships while playing for the New York Yankees.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Joe DiMaggio?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A career batting average of .325 and 361 home runs highlight an elite offensive profile. Beyond the numbers, the center fielder was a three-time MVP and a 13-time All-Star. The combination of defensive excellence and consistent hitting made the player a central figure in the sport&#x27;s golden era.">How would you summarize the overall impact of this player on Major League Baseball?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The team reached the World Series in 10 of the 13 seasons the player was on the roster, winning nine titles. In 51 career World Series games, the outfielder recorded 8 home runs and 30 RBIs. This postseason dominance remains a cornerstone of the franchise&#x27;s historical success.">What was the significance of this player&#x27;s tenure with the New York Yankees in the postseason?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Yes, three seasons were missed due to service in the United States Army Air Forces during World War II. The player enlisted in 1943 and served until 1945, primarily working as a physical education instructor. This service interrupted what would have been the prime years of a legendary career.">Did this player serve in the military during their professional career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>79.1</td><td>6821</td><td>2214</td><td>361</td><td>.325</td><td>1390</td><td>1537</td><td>30</td><td>.398</td><td>.579</td><td>.977</td><td>155</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-03-27.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Joe DiMaggio" src="images/answer-2026-03-27.webp"/>
+</div>
+<div class="player-info">
+<h2>Joe DiMaggio "Joltin' Joe, The Yankee Clipper"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Maintained a record 56-game hitting streak during the 1941 season.</li>
+<li>Earned three American League Most Valuable Player awards throughout a 13-season career.</li>
+<li>Secured nine World Series championships while playing for the New York Yankees.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Joe DiMaggio?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="A career batting average of .325 and 361 home runs highlight an elite offensive profile. Beyond the numbers, the center fielder was a three-time MVP and a 13-time All-Star. The combination of defensive excellence and consistent hitting made the player a central figure in the sport's golden era.">How would you summarize the overall impact of this player on Major League Baseball?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The team reached the World Series in 10 of the 13 seasons the player was on the roster, winning nine titles. In 51 career World Series games, the outfielder recorded 8 home runs and 30 RBIs. This postseason dominance remains a cornerstone of the franchise's historical success.">What was the significance of this player's tenure with the New York Yankees in the postseason?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, three seasons were missed due to service in the United States Army Air Forces during World War II. The player enlisted in 1943 and served until 1945, primarily working as a physical education instructor. This service interrupted what would have been the prime years of a legendary career.">Did this player serve in the military during their professional career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>79.1</td><td>6821</td><td>2214</td><td>361</td><td>.325</td><td>1390</td><td>1537</td><td>30</td><td>.398</td><td>.579</td><td>.977</td><td>155</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-03-27.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1936", "1937", "1938", "1939", "1940", "1941", "1942", "1946", "1947", "1948", "1949", "1950", "1951"];
             const warData = [4.8, 8.4, 5.7, 8.3, 7.1, 9.3, 6.4, 5.2, 4.7, 6.9, 4.3, 5.2, 2.9];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["NYY"], "years": ["1946", "1942", "1947", "1949", "1940", "1936", "1951", "1937", "1938", "1948", "1950", "1941", "1939"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Joe DiMaggio", "hints": ["Maintained a record 56-game hitting streak during the 1941 season.", "Earned three American League Most Valuable Player awards throughout a 13-season career.", "Secured nine World Series championships while playing for the New York Yankees."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["NYY"], "years": ["1946", "1942", "1947", "1949", "1940", "1936", "1951", "1937", "1938", "1948", "1950", "1941", "1939"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Joe DiMaggio", "hints": ["Maintained a record 56-game hitting streak during the 1941 season.", "Earned three American League Most Valuable Player awards throughout a 13-season career.", "Secured nine World Series championships while playing for the New York Yankees."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 27-Mar-2026</p>
-    </footer>    
+<p>Last Updated: 27-Mar-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-03-30.html
+++ b/2026-03-30.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-03-30 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-03-30">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is David Weathers.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - March 30, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-03-30.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - March 30, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-03-30.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-30" rel="canonical"/><meta content='Discover the career highlights and statistics for David Weathers "Stormy", the featured New York Yankee for the 2026-03-30 trivia puzzle.' name="description"/>
+<title>Answer for 2026-03-30 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 30, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-30.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 30, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-30.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for March 30, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for March 30, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-03-30.webp" alt="Photo of David Weathers">
-                    </div>
-                    <div class="player-info">
-                        <h2>David Weathers "Stormy"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Pitched for a record-tying nine different Major League Baseball franchises over a 19-season career.</li>
-                        <li>Earned a World Series championship ring as a member of the 1996 New York Yankees.</li>
-                        <li>Recorded 964 career appearances, ranking among the top 20 all-time leaders in games pitched.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about David Weathers?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Starting as a starter for the Marlins in their inaugural 1993 season, the right-hander eventually transitioned into a reliable middle-to-late inning specialist. Over nearly two decades, the pitcher provided consistent depth for teams like the Reds, Brewers, and Mets. The career concluded with 71 wins, 72 saves, and a reputation as a workhorse who could handle high-leverage situations.">How would you summarize the career trajectory of this durable relief pitcher?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The pitcher appeared in 47 games for the 1996 Yankees, posting a 3.72 ERA while helping the team secure the American League East title. During the postseason, the right-hander made three appearances, including a scoreless inning in Game 4 of the World Series against the Atlanta Braves. This performance helped the Yankees overcome a 2-0 series deficit to win their first championship since 1978.">What was the most significant contribution made during the 1996 season with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The pitcher is famously known for being the player traded to the Cincinnati Reds in 1998 in exchange for future Hall of Famer Mike Lowell. Additionally, the right-hander played for the Florida Marlins during their very first game in franchise history in 1993. This longevity allowed for a rare career span that bridged the gap between the expansion era of the early 90s and the modern bullpen-heavy era.">Is there any interesting trivia regarding the longevity or unique circumstances of this player&#x27;s career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
-                    <tbody><tr><td>10.4</td><td>73</td><td>88</td><td>4.25</td><td>964</td><td>69</td><td>75</td><td>1376.1</td><td>976</td><td>1.479</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-03-30.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of David Weathers" src="images/answer-2026-03-30.webp"/>
+</div>
+<div class="player-info">
+<h2>David Weathers "Stormy"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Pitched for a record-tying nine different Major League Baseball franchises over a 19-season career.</li>
+<li>Earned a World Series championship ring as a member of the 1996 New York Yankees.</li>
+<li>Recorded 964 career appearances, ranking among the top 20 all-time leaders in games pitched.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about David Weathers?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Starting as a starter for the Marlins in their inaugural 1993 season, the right-hander eventually transitioned into a reliable middle-to-late inning specialist. Over nearly two decades, the pitcher provided consistent depth for teams like the Reds, Brewers, and Mets. The career concluded with 71 wins, 72 saves, and a reputation as a workhorse who could handle high-leverage situations.">How would you summarize the career trajectory of this durable relief pitcher?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The pitcher appeared in 47 games for the 1996 Yankees, posting a 3.72 ERA while helping the team secure the American League East title. During the postseason, the right-hander made three appearances, including a scoreless inning in Game 4 of the World Series against the Atlanta Braves. This performance helped the Yankees overcome a 2-0 series deficit to win their first championship since 1978.">What was the most significant contribution made during the 1996 season with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The pitcher is famously known for being the player traded to the Cincinnati Reds in 1998 in exchange for future Hall of Famer Mike Lowell. Additionally, the right-hander played for the Florida Marlins during their very first game in franchise history in 1993. This longevity allowed for a rare career span that bridged the gap between the expansion era of the early 90s and the modern bullpen-heavy era.">Is there any interesting trivia regarding the longevity or unique circumstances of this player's career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
+<tbody><tr><td>10.4</td><td>73</td><td>88</td><td>4.25</td><td>964</td><td>69</td><td>75</td><td>1376.1</td><td>976</td><td>1.479</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-03-30.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003", "2004", "2005", "2006", "2007", "2008", "2009"];
             const warData = [-0.1, -0.1, 0.2, -0.5, -1.4, -0.7, -0.7, -0.4, 0.7, 1.5, 2.6, 1.2, 2.2, 0.0, 0.9, 1.7, 1.9, 1.5, 0.4];
             const teamsByYear = ["TOR", "TOR", "FLA", "FLA", "FLA", "2TM", "2TM", "2TM", "MIL", "MIL", "2TM", "NYM", "NYM", "3TM", "CIN", "CIN", "CIN", "CIN", "2TM"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["TOR", "NYY", "HOU", "MIL", "CLE", "NYM", "CHC", "FLA", "CIN"], "years": ["1996", "2001", "1991", "1994", "2003", "1992", "2002", "2006", "2005", "1993", "1999", "1997", "2000", "2009", "1995", "2007", "2008", "2004", "1998"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "David Weathers", "hints": ["Pitched for a record-tying nine different Major League Baseball franchises over a 19-season career.", "Earned a World Series championship ring as a member of the 1996 New York Yankees.", "Recorded 964 career appearances, ranking among the top 20 all-time leaders in games pitched."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["TOR", "NYY", "HOU", "MIL", "CLE", "NYM", "CHC", "FLA", "CIN"], "years": ["1996", "2001", "1991", "1994", "2003", "1992", "2002", "2006", "2005", "1993", "1999", "1997", "2000", "2009", "1995", "2007", "2008", "2004", "1998"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "David Weathers", "hints": ["Pitched for a record-tying nine different Major League Baseball franchises over a 19-season career.", "Earned a World Series championship ring as a member of the 1996 New York Yankees.", "Recorded 964 career appearances, ranking among the top 20 all-time leaders in games pitched."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 31-Mar-2026</p>
-    </footer>    
+<p>Last Updated: 31-Mar-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-03-31.html
+++ b/2026-03-31.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-03-31 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-03-31">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Ken Clay.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - March 31, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-03-31.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - March 31, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-03-31.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-03-31" rel="canonical"/><meta content="Discover the career highlights and statistics for Ken Clay, the featured New York Yankee for the 2026-03-31 trivia puzzle." name="description"/>
+<title>Answer for 2026-03-31 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - March 31, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-03-31.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - March 31, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-03-31.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for March 31, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for March 31, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-03-31.webp" alt="Photo of Ken Clay">
-                    </div>
-                    <div class="player-info">
-                        <h2>Ken Clay</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Selected by the New York Yankees in the first round of the 1971 MLB draft.</li>
-                        <li>Recorded a career-high 10 wins during the 1979 season.</li>
-                        <li>Pitched for four different franchises across a seven-season major league career.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Ken Clay?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A first-round draft pick, the right-hander spent his most productive years with the New York Yankees before moving on to the Seattle Mariners, Texas Rangers, and Cleveland Indians. He primarily served as a versatile arm, transitioning between starting and relief roles throughout his time in the majors. He concluded his career with a 27-35 record and a 4.15 ERA over 189 appearances.">How would you summarize the professional trajectory of this pitcher?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="He was a member of the 1978 World Series championship team, though he did not appear in the postseason that year. During the 1979 season, he provided valuable depth for the pitching staff, logging 148 innings and making 21 starts. His ability to eat innings during that campaign helped stabilize a rotation that faced various injuries.">What was the role of this player during the Yankees&#x27; championship runs in the late 1970s?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Following his retirement from Major League Baseball, he transitioned into a career in law enforcement. He served as a police officer in his home state of Virginia for many years. This post-baseball career path is a rare example of a former first-round draft pick moving into public service work.">Did this player have any notable experiences or unique circumstances during his time in professional baseball?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
-                    <tbody><tr><td>-1.2</td><td>10</td><td>24</td><td>4.68</td><td>111</td><td>36</td><td>3</td><td>353.2</td><td>129</td><td>1.499</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-03-31.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Ken Clay" src="images/answer-2026-03-31.webp"/>
+</div>
+<div class="player-info">
+<h2>Ken Clay</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Selected by the New York Yankees in the first round of the 1971 MLB draft.</li>
+<li>Recorded a career-high 10 wins during the 1979 season.</li>
+<li>Pitched for four different franchises across a seven-season major league career.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Ken Clay?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="A first-round draft pick, the right-hander spent his most productive years with the New York Yankees before moving on to the Seattle Mariners, Texas Rangers, and Cleveland Indians. He primarily served as a versatile arm, transitioning between starting and relief roles throughout his time in the majors. He concluded his career with a 27-35 record and a 4.15 ERA over 189 appearances.">How would you summarize the professional trajectory of this pitcher?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="He was a member of the 1978 World Series championship team, though he did not appear in the postseason that year. During the 1979 season, he provided valuable depth for the pitching staff, logging 148 innings and making 21 starts. His ability to eat innings during that campaign helped stabilize a rotation that faced various injuries.">What was the role of this player during the Yankees' championship runs in the late 1970s?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Following his retirement from Major League Baseball, he transitioned into a career in law enforcement. He served as a police officer in his home state of Virginia for many years. This post-baseball career path is a rare example of a former first-round draft pick moving into public service work.">Did this player have any notable experiences or unique circumstances during his time in professional baseball?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
+<tbody><tr><td>-1.2</td><td>10</td><td>24</td><td>4.68</td><td>111</td><td>36</td><td>3</td><td>353.2</td><td>129</td><td>1.499</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-03-31.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1977", "1978", "1979", "1980", "1981"];
             const warData = [-0.4, -0.3, -0.8, 0.5, -0.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "TEX", "SEA"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["SEA", "NYY", "TEX"], "years": ["1979", "1977", "1980", "1978", "1981"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Ken Clay", "nickname": "", "hints": ["Selected by the New York Yankees in the first round of the 1971 MLB draft.", "Recorded a career-high 10 wins during the 1979 season.", "Pitched for four different franchises across a seven-season major league career."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["SEA", "NYY", "TEX"], "years": ["1979", "1977", "1980", "1978", "1981"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Ken Clay", "nickname": "", "hints": ["Selected by the New York Yankees in the first round of the 1971 MLB draft.", "Recorded a career-high 10 wins during the 1979 season.", "Pitched for four different franchises across a seven-season major league career."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 02-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 02-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-01.html
+++ b/2026-04-01.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-01 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-01">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mike Morgan.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 01, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-01.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 01, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-01.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-01" rel="canonical"/><meta content='Discover the career highlights and statistics for Mike Morgan "The Nomad", the featured New York Yankee for the 2026-04-01 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-01 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 01, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-01.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 01, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-01.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 01, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 01, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-01.webp" alt="Photo of Mike Morgan">
-                    </div>
-                    <div class="player-info">
-                        <h2>Mike Morgan "The Nomad"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Played for a record-tying 12 different major league franchises over a 22-season career.</li>
-                        <li>Debuted as an 18-year-old phenom directly from high school in 1978.</li>
-                        <li>Earned a World Series championship ring with the 2001 Arizona Diamondbacks.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Mike Morgan?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Starting as a highly touted teenage prospect with the Oakland Athletics, the right-hander evolved into a durable journeyman workhorse. Over 22 seasons, 467 starts, and 2,700 innings, the pitcher provided consistent depth for a dozen different clubs. The career concluded with a total of 141 wins and a memorable championship run in the final season.">How would you summarize the overall trajectory of this pitcher&#x27;s long career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The stint in the Bronx was brief, occurring during the 1983 season after a trade from the Toronto Blue Jays. In 24 appearances, including 15 starts, the pitcher recorded a 7-7 record with a 4.15 ERA. This period served as a transitional phase before moving on to the Baltimore Orioles the following year.">What was the nature of the tenure with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The player is famously known for being the first major leaguer to play for 12 different franchises, a record that stood for years before being matched by others. This nomadic career path earned the nickname &#x27;The Traveling Man&#x27; among baseball circles. Despite the constant movement, the pitcher remained a reliable presence on major league rosters for over two decades.">Is there a unique or quirky aspect to this player&#x27;s professional journey?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
-                    <tbody><tr><td>26.2</td><td>141</td><td>186</td><td>4.23</td><td>597</td><td>411</td><td>8</td><td>2772.1</td><td>1403</td><td>1.400</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-01.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mike Morgan" src="images/answer-2026-04-01.webp"/>
+</div>
+<div class="player-info">
+<h2>Mike Morgan "The Nomad"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Played for a record-tying 12 different major league franchises over a 22-season career.</li>
+<li>Debuted as an 18-year-old phenom directly from high school in 1978.</li>
+<li>Earned a World Series championship ring with the 2001 Arizona Diamondbacks.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Mike Morgan?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Starting as a highly touted teenage prospect with the Oakland Athletics, the right-hander evolved into a durable journeyman workhorse. Over 22 seasons, 467 starts, and 2,700 innings, the pitcher provided consistent depth for a dozen different clubs. The career concluded with a total of 141 wins and a memorable championship run in the final season.">How would you summarize the overall trajectory of this pitcher's long career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The stint in the Bronx was brief, occurring during the 1983 season after a trade from the Toronto Blue Jays. In 24 appearances, including 15 starts, the pitcher recorded a 7-7 record with a 4.15 ERA. This period served as a transitional phase before moving on to the Baltimore Orioles the following year.">What was the nature of the tenure with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The player is famously known for being the first major leaguer to play for 12 different franchises, a record that stood for years before being matched by others. This nomadic career path earned the nickname 'The Traveling Man' among baseball circles. Despite the constant movement, the pitcher remained a reliable presence on major league rosters for over two decades.">Is there a unique or quirky aspect to this player's professional journey?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
+<tbody><tr><td>26.2</td><td>141</td><td>186</td><td>4.23</td><td>597</td><td>411</td><td>8</td><td>2772.1</td><td>1403</td><td>1.400</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-01.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1978", "1979", "1982", "1983", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002"];
             const warData = [-0.4, 0.0, 2.0, 0.1, -0.3, 2.6, 2.8, -0.3, 3.0, 1.5, 5.1, 5.4, 1.5, -1.3, 1.9, 0.7, 1.0, 3.2, -0.5, 0.6, 0.3, -0.1];
             const teamsByYear = ["OAK", "OAK", "NYY", "TOR", "SEA", "SEA", "SEA", "BAL", "LAD", "LAD", "LAD", "CHC", "CHC", "CHC", "2TM", "2TM", "CIN", "2TM", "TEX", "ARI", "ARI", "ARI"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["OAK", "LAD", "TEX", "MIN", "CHC", "TOR", "STL", "BAL", "NYY", "ARI", "CIN", "SEA"], "years": ["1982", "2001", "1994", "1993", "2002", "1990", "1996", "1992", "1999", "1995", "1986", "1983", "1998", "1991", "1988", "1997", "2000", "1985", "1979", "1978", "1987", "1989"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Mike Morgan", "nickname": "The Nomad", "hints": ["Played for a record-tying 12 different major league franchises over a 22-season career.", "Debuted as an 18-year-old phenom directly from high school in 1978.", "Earned a World Series championship ring with the 2001 Arizona Diamondbacks."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["OAK", "LAD", "TEX", "MIN", "CHC", "TOR", "STL", "BAL", "NYY", "ARI", "CIN", "SEA"], "years": ["1982", "2001", "1994", "1993", "2002", "1990", "1996", "1992", "1999", "1995", "1986", "1983", "1998", "1991", "1988", "1997", "2000", "1985", "1979", "1978", "1987", "1989"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Mike Morgan", "nickname": "The Nomad", "hints": ["Played for a record-tying 12 different major league franchises over a 22-season career.", "Debuted as an 18-year-old phenom directly from high school in 1978.", "Earned a World Series championship ring with the 2001 Arizona Diamondbacks."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 02-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 02-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-03.html
+++ b/2026-04-03.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-03 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-03">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jon Berti.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 03, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-03.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 03, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-03.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-03" rel="canonical"/><meta content='Discover the career highlights and statistics for Jon Berti "Birdman", the featured New York Yankee for the 2026-04-03 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-03 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 03, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-03.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 03, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-03.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 03, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 03, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-03.webp" alt="Photo of Jon Berti">
-                    </div>
-                    <div class="player-info">
-                        <h2>Jon Berti "Birdman"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Led the National League in stolen bases during the 2022 season.</li>
-                        <li>Drafted by the Toronto Blue Jays in the 18th round of the 2011 MLB Draft.</li>
-                        <li>Recorded a career-high 41 stolen bases while playing for the Miami Marlins in 2022.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Jon Berti?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="After spending several years in the minor leagues, the utility player established himself as a versatile major league contributor known for speed and defensive flexibility. The career has been defined by the ability to play multiple positions across the infield and outfield while serving as a consistent base-stealing threat. This reliability has made the player a valuable asset for teams seeking depth and late-game tactical advantages.">How would you describe the general trajectory of this player&#x27;s professional career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Acquired via trade earlier in the 2024 season, the utility man provided depth for the Yankees during their run to the World Series. While injuries limited regular-season availability, the player appeared in postseason games as a defensive replacement and pinch runner. The versatility allowed the coaching staff to shuffle the lineup during high-leverage moments in the ALCS and World Series.">What role did this player have for the New York Yankees during the 2024 postseason?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The path to the majors involved a long tenure in the minor leagues, spanning seven seasons before finally reaching the big leagues with Toronto in 2018. This persistence is often cited by teammates as a testament to a strong work ethic and adaptability. The player attended Bowling Green State University, where the baseball program was famously cut shortly after graduation, adding a layer of historical significance to the collegiate career.">Is there anything unique about the player&#x27;s background or path to the major leagues?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>8.5</td><td>1536</td><td>393</td><td>24</td><td>.256</td><td>232</td><td>128</td><td>108</td><td>.333</td><td>.357</td><td>.690</td><td>89</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-03.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Jon Berti" src="images/answer-2026-04-03.webp"/>
+</div>
+<div class="player-info">
+<h2>Jon Berti "Birdman"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Led the National League in stolen bases during the 2022 season.</li>
+<li>Drafted by the Toronto Blue Jays in the 18th round of the 2011 MLB Draft.</li>
+<li>Recorded a career-high 41 stolen bases while playing for the Miami Marlins in 2022.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Jon Berti?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="After spending several years in the minor leagues, the utility player established himself as a versatile major league contributor known for speed and defensive flexibility. The career has been defined by the ability to play multiple positions across the infield and outfield while serving as a consistent base-stealing threat. This reliability has made the player a valuable asset for teams seeking depth and late-game tactical advantages.">How would you describe the general trajectory of this player's professional career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Acquired via trade earlier in the 2024 season, the utility man provided depth for the Yankees during their run to the World Series. While injuries limited regular-season availability, the player appeared in postseason games as a defensive replacement and pinch runner. The versatility allowed the coaching staff to shuffle the lineup during high-leverage moments in the ALCS and World Series.">What role did this player have for the New York Yankees during the 2024 postseason?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The path to the majors involved a long tenure in the minor leagues, spanning seven seasons before finally reaching the big leagues with Toronto in 2018. This persistence is often cited by teammates as a testament to a strong work ethic and adaptability. The player attended Bowling Green State University, where the baseball program was famously cut shortly after graduation, adding a layer of historical significance to the collegiate career.">Is there anything unique about the player's background or path to the major leagues?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>8.5</td><td>1536</td><td>393</td><td>24</td><td>.256</td><td>232</td><td>128</td><td>108</td><td>.333</td><td>.357</td><td>.690</td><td>89</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-03.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025"];
             const warData = [0.1, 1.6, 0.9, 0.6, 2.4, 2.2, 0.7, 0.2];
             const teamsByYear = ["TOR", "MIA", "MIA", "MIA", "MIA", "MIA", "NYY", "CHC"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["NYY", "MIA", "CHC", "TOR"], "years": ["2022", "2024", "2019", "2018", "2020", "2021", "2025", "2023"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Jon Berti", "nickname": "Birdman", "hints": ["Led the National League in stolen bases during the 2022 season.", "Drafted by the Toronto Blue Jays in the 18th round of the 2011 MLB Draft.", "Recorded a career-high 41 stolen bases while playing for the Miami Marlins in 2022."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["NYY", "MIA", "CHC", "TOR"], "years": ["2022", "2024", "2019", "2018", "2020", "2021", "2025", "2023"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Jon Berti", "nickname": "Birdman", "hints": ["Led the National League in stolen bases during the 2022 season.", "Drafted by the Toronto Blue Jays in the 18th round of the 2011 MLB Draft.", "Recorded a career-high 41 stolen bases while playing for the Miami Marlins in 2022."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 03-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 03-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-04.html
+++ b/2026-04-04.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-04 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-04">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Mark Hutton.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 04, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-04.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 04, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-04.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-04" rel="canonical"/><meta content="Discover the career highlights and statistics for Mark Hutton, the featured New York Yankee for the 2026-04-04 trivia puzzle." name="description"/>
+<title>Answer for 2026-04-04 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 04, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-04.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 04, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-04.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 04, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 04, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-04.webp" alt="Photo of Mark Hutton">
-                    </div>
-                    <div class="player-info">
-                        <h2>Mark Hutton</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Became the first Australian-born pitcher to appear in a Major League Baseball game.</li>
-                        <li>Recorded a career-high 54 strikeouts during the 1996 season.</li>
-                        <li>Pitched for five different organizations across a six-year major league career.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Mark Hutton?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The right-hander spent six seasons in the major leagues between 1993 and 1998. Primarily serving as a relief pitcher, the journeyman played for the Yankees, Marlins, Rockies, Cardinals, and Reds. He finished his big league career with a 4.96 ERA over 165 appearances.">How would you summarize the professional trajectory of this pitcher?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The pitcher spent his first three seasons in the Bronx, appearing in 78 games for the team. His most productive year with the club was 1996, where he posted a 3.69 ERA across 46.1 innings. He was a member of the organization during the transition period that preceded their late-90s dynasty.">What was the most significant contribution made while wearing a New York Yankees uniform?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Beyond his MLB career, he was a pioneer for Australian baseball, helping pave the way for future players from his home country. After his time in the United States, he returned to Australia to continue his involvement in the sport. He eventually served as a pitching coach for the Australian national team in international competitions.">Did this player have any notable experiences outside of his time in the major leagues?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
-                    <tbody><tr><td>0.9</td><td>9</td><td>7</td><td>4.75</td><td>84</td><td>18</td><td>0</td><td>189.2</td><td>111</td><td>1.576</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-04.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Mark Hutton" src="images/answer-2026-04-04.webp"/>
+</div>
+<div class="player-info">
+<h2>Mark Hutton</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Became the first Australian-born pitcher to appear in a Major League Baseball game.</li>
+<li>Recorded a career-high 54 strikeouts during the 1996 season.</li>
+<li>Pitched for five different organizations across a six-year major league career.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Mark Hutton?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The right-hander spent six seasons in the major leagues between 1993 and 1998. Primarily serving as a relief pitcher, the journeyman played for the Yankees, Marlins, Rockies, Cardinals, and Reds. He finished his big league career with a 4.96 ERA over 165 appearances.">How would you summarize the professional trajectory of this pitcher?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The pitcher spent his first three seasons in the Bronx, appearing in 78 games for the team. His most productive year with the club was 1996, where he posted a 3.69 ERA across 46.1 innings. He was a member of the organization during the transition period that preceded their late-90s dynasty.">What was the most significant contribution made while wearing a New York Yankees uniform?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Beyond his MLB career, he was a pioneer for Australian baseball, helping pave the way for future players from his home country. After his time in the United States, he returned to Australia to continue his involvement in the sport. He eventually served as a pitching coach for the Australian national team in international competitions.">Did this player have any notable experiences outside of his time in the major leagues?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>W</th><th>L</th><th>ERA</th><th>G</th><th>GS</th><th>SV</th><th>IP</th><th>SO</th><th>WHIP</th></tr></thead>
+<tbody><tr><td>0.9</td><td>9</td><td>7</td><td>4.75</td><td>84</td><td>18</td><td>0</td><td>189.2</td><td>111</td><td>1.576</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-04.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1993", "1994", "1996", "1997", "1998"];
             const warData = [-0.3, 0.0, 1.3, 0.1, -0.3];
             const teamsByYear = ["NYY", "NYY", "2TM", "2TM", "CIN"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["CIN", "COL", "FLA", "NYY"], "years": ["1993", "1998", "1997", "1996", "1994"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Mark Hutton", "nickname": "", "hints": ["Became the first Australian-born pitcher to appear in a Major League Baseball game.", "Recorded a career-high 54 strikeouts during the 1996 season.", "Pitched for five different organizations across a six-year major league career."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["CIN", "COL", "FLA", "NYY"], "years": ["1993", "1998", "1997", "1996", "1994"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Mark Hutton", "nickname": "", "hints": ["Became the first Australian-born pitcher to appear in a Major League Baseball game.", "Recorded a career-high 54 strikeouts during the 1996 season.", "Pitched for five different organizations across a six-year major league career."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 04-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 04-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-05.html
+++ b/2026-04-05.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-05 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-05">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Austin Slater.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 05, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-05.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 05, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-05.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-05" rel="canonical"/><meta content="Discover the career highlights and statistics for Austin Slater, the featured New York Yankee for the 2026-04-05 trivia puzzle." name="description"/>
+<title>Answer for 2026-04-05 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 05, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-05.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 05, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-05.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 05, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 05, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-05.webp" alt="Photo of Austin Slater">
-                    </div>
-                    <div class="player-info">
-                        <h2>Austin Slater</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Selected in the eighth round of the 2014 MLB Draft by the San Francisco Giants out of Stanford University.</li>
-                        <li>Recorded a career-high 12 home runs during the 2021 season while serving primarily as a platoon outfielder.</li>
-                        <li>Traded to the Cincinnati Reds in July 2024 before being dealt to the Baltimore Orioles later that same month.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Austin Slater?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The career has been defined by a specialized role as a platoon outfielder, specifically utilized to provide production against left-handed pitching. This tactical usage has allowed for consistent contributions in on-base percentage and power metrics despite limited opportunities against right-handed starters.">How would you characterize the primary role played throughout this career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="There are no postseason moments or records to report, as this player has never been a member of the New York Yankees organization. The career has been spent primarily with the San Francisco Giants, followed by brief stints with the Cincinnati Reds and Baltimore Orioles.">What are the most notable postseason moments or records achieved while playing for the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="During the COVID-19 pandemic, a significant interest in the stock market and day trading emerged as a way to stay occupied during the shutdown. This hobby became a notable talking point in interviews, highlighting a disciplined approach to financial analysis that mirrored a professional focus on scouting reports.">Are there any interesting details regarding off-field interests or unique personal background?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>4.9</td><td>1639</td><td>405</td><td>45</td><td>.247</td><td>232</td><td>185</td><td>49</td><td>.335</td><td>.382</td><td>.717</td><td>99</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-05.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Austin Slater" src="images/answer-2026-04-05.webp"/>
+</div>
+<div class="player-info">
+<h2>Austin Slater</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Selected in the eighth round of the 2014 MLB Draft by the San Francisco Giants out of Stanford University.</li>
+<li>Recorded a career-high 12 home runs during the 2021 season while serving primarily as a platoon outfielder.</li>
+<li>Traded to the Cincinnati Reds in July 2024 before being dealt to the Baltimore Orioles later that same month.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Austin Slater?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The career has been defined by a specialized role as a platoon outfielder, specifically utilized to provide production against left-handed pitching. This tactical usage has allowed for consistent contributions in on-base percentage and power metrics despite limited opportunities against right-handed starters.">How would you characterize the primary role played throughout this career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="There are no postseason moments or records to report, as this player has never been a member of the New York Yankees organization. The career has been spent primarily with the San Francisco Giants, followed by brief stints with the Cincinnati Reds and Baltimore Orioles.">What are the most notable postseason moments or records achieved while playing for the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During the COVID-19 pandemic, a significant interest in the stock market and day trading emerged as a way to stay occupied during the shutdown. This hobby became a notable talking point in interviews, highlighting a disciplined approach to financial analysis that mirrored a professional focus on scouting reports.">Are there any interesting details regarding off-field interests or unique personal background?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>4.9</td><td>1639</td><td>405</td><td>45</td><td>.247</td><td>232</td><td>185</td><td>49</td><td>.335</td><td>.382</td><td>.717</td><td>99</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-05.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["2017", "2018", "2019", "2020", "2021", "2022", "2023", "2024", "2025", "2026"];
             const warData = [0.2, -0.2, 0.7, 0.9, 1.4, 1.6, 0.8, -0.3, -0.1, -0.1];
             const teamsByYear = ["SFG", "SFG", "SFG", "SFG", "SFG", "SFG", "SFG", "3TM", "2TM", "MIA"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["CIN", "NYY", "2TM", "CHW", "MIA", "SFG", "BAL"], "years": ["2024", "2025", "2026", "2021", "2023", "2019", "2022", "2020", "2017", "2018"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Austin Slater", "nickname": "", "hints": ["Selected in the eighth round of the 2014 MLB Draft by the San Francisco Giants out of Stanford University.", "Recorded a career-high 12 home runs during the 2021 season while serving primarily as a platoon outfielder.", "Traded to the Cincinnati Reds in July 2024 before being dealt to the Baltimore Orioles later that same month."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["CIN", "NYY", "2TM", "CHW", "MIA", "SFG", "BAL"], "years": ["2024", "2025", "2026", "2021", "2023", "2019", "2022", "2020", "2017", "2018"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Austin Slater", "nickname": "", "hints": ["Selected in the eighth round of the 2014 MLB Draft by the San Francisco Giants out of Stanford University.", "Recorded a career-high 12 home runs during the 2021 season while serving primarily as a platoon outfielder.", "Traded to the Cincinnati Reds in July 2024 before being dealt to the Baltimore Orioles later that same month."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 05-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 05-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-07.html
+++ b/2026-04-07.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-07 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-07">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Rickey Henderson.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 07, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-07.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 07, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-07.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-07" rel="canonical"/><meta content='Discover the career highlights and statistics for Rickey Henderson "Man of Steal", the featured New York Yankee for the 2026-04-07 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-07 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 07, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-07.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 07, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-07.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 07, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 07, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-07.webp" alt="Photo of Rickey Henderson">
-                    </div>
-                    <div class="player-info">
-                        <h2>Rickey Henderson "Man of Steal"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Holds the all-time Major League Baseball records for stolen bases and runs scored.</li>
-                        <li>Earned the 1990 American League Most Valuable Player award.</li>
-                        <li>Achieved induction into the National Baseball Hall of Fame on the first ballot in 2009.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Rickey Henderson?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Widely considered the greatest leadoff hitter ever, this player revolutionized the game with an unprecedented combination of power and speed. Over a 25-season career, 1,406 stolen bases and 2,295 runs scored stand as monumental records that remain untouched. Beyond the numbers, the ability to draw walks and consistently reach base made this player a nightmare for opposing pitchers.">What defines the overall legacy of this player in baseball history?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="During four seasons in New York, this player provided elite production, including a 1985 campaign where 80 stolen bases and 146 runs scored were recorded. Notably, the 1985 season saw a career-high 24 home runs while playing center field. This tenure solidified a reputation as a premier offensive force in the American League.">How did this player perform during the tenure with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="This player was famous for referring to oneself in the third person during interviews and daily conversation. One of the most legendary stories involves a phone call to a general manager to negotiate a contract, where the player famously declared, &#x27;Rickey wants to play for the Yankees.&#x27; This habit became a defining part of a larger-than-life public persona.">Is there a famous anecdote regarding this player&#x27;s personality or self-perception?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>111.2</td><td>10961</td><td>3055</td><td>297</td><td>.279</td><td>2295</td><td>1115</td><td>1406</td><td>.401</td><td>.419</td><td>.820</td><td>127</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-07.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Rickey Henderson" src="images/answer-2026-04-07.webp"/>
+</div>
+<div class="player-info">
+<h2>Rickey Henderson "Man of Steal"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Holds the all-time Major League Baseball records for stolen bases and runs scored.</li>
+<li>Earned the 1990 American League Most Valuable Player award.</li>
+<li>Achieved induction into the National Baseball Hall of Fame on the first ballot in 2009.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Rickey Henderson?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="Widely considered the greatest leadoff hitter ever, this player revolutionized the game with an unprecedented combination of power and speed. Over a 25-season career, 1,406 stolen bases and 2,295 runs scored stand as monumental records that remain untouched. Beyond the numbers, the ability to draw walks and consistently reach base made this player a nightmare for opposing pitchers.">What defines the overall legacy of this player in baseball history?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During four seasons in New York, this player provided elite production, including a 1985 campaign where 80 stolen bases and 146 runs scored were recorded. Notably, the 1985 season saw a career-high 24 home runs while playing center field. This tenure solidified a reputation as a premier offensive force in the American League.">How did this player perform during the tenure with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="This player was famous for referring to oneself in the third person during interviews and daily conversation. One of the most legendary stories involves a phone call to a general manager to negotiate a contract, where the player famously declared, 'Rickey wants to play for the Yankees.' This habit became a defining part of a larger-than-life public persona.">Is there a famous anecdote regarding this player's personality or self-perception?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>111.2</td><td>10961</td><td>3055</td><td>297</td><td>.279</td><td>2295</td><td>1115</td><td>1406</td><td>.401</td><td>.419</td><td>.820</td><td>127</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-07.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002", "2003"];
             const warData = [-0.9, 8.8, 6.7, 6.7, 6.9, 6.0, 9.9, 6.3, 4.7, 6.3, 8.7, 9.9, 4.6, 5.6, 5.0, 3.5, 2.9, 1.9, 1.6, 2.3, 1.9, 0.7, 0.5, 0.4, 0.2];
             const teamsByYear = ["OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "NYY", "NYY", "NYY", "NYY", "2TM", "OAK", "OAK", "OAK", "2TM", "OAK", "OAK", "SDP", "2TM", "OAK", "NYM", "2TM", "SDP", "BOS", "LAD"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["OAK", "ANA", "TOR", "BOS", "SDP", "NYY", "LAD", "NYM", "SEA"], "years": ["1993", "1979", "2001", "2003", "1980", "1984", "2002", "1981", "1989", "1998", "1990", "1991", "1995", "1982", "1988", "1986", "1994", "1996", "1999", "1987", "1985", "2000", "1983", "1997", "1992"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Rickey Henderson", "nickname": "Man of Steal", "hints": ["Holds the all-time Major League Baseball records for stolen bases and runs scored.", "Earned the 1990 American League Most Valuable Player award.", "Achieved induction into the National Baseball Hall of Fame on the first ballot in 2009."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["OAK", "ANA", "TOR", "BOS", "SDP", "NYY", "LAD", "NYM", "SEA"], "years": ["1993", "1979", "2001", "2003", "1980", "1984", "2002", "1981", "1989", "1998", "1990", "1991", "1995", "1982", "1988", "1986", "1994", "1996", "1999", "1987", "1985", "2000", "1983", "1997", "1992"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Rickey Henderson", "nickname": "Man of Steal", "hints": ["Holds the all-time Major League Baseball records for stolen bases and runs scored.", "Earned the 1990 American League Most Valuable Player award.", "Achieved induction into the National Baseball Hall of Fame on the first ballot in 2009."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 07-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 07-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-08.html
+++ b/2026-04-08.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-08 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-08">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Jos\u00e9 Canseco.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 08, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-08.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 08, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-08.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-08" rel="canonical"/><meta content='Discover the career highlights and statistics for José Canseco "The Chemist", the featured New York Yankee for the 2026-04-08 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-08 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 08, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-08.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 08, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-08.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 08, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 08, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-08.webp" alt="Photo of José Canseco">
-                    </div>
-                    <div class="player-info">
-                        <h2>José Canseco "The Chemist"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Became the first player in Major League Baseball history to join the 40-40 club during the 1988 season.</li>
-                        <li>Earned the 1986 American League Rookie of the Year award and the 1988 American League Most Valuable Player award.</li>
-                        <li>Won two World Series championships, one with the Oakland Athletics in 1989 and one with the New York Yankees in 2000.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about José Canseco?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="As a central figure of the &#x27;Bash Brothers&#x27; era, this player revolutionized the game by combining elite power with stolen-base speed. This unique skill set led to the first 40-40 season in history and helped the Oakland Athletics reach three consecutive World Series from 1988 to 1990. The player finished a 17-year career with 462 home runs and 200 stolen bases.">How would you summarize the overall impact of this player on the game during the late 1980s?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The Yankees acquired the veteran slugger off waivers from the Tampa Bay Devil Rays in August 2000 to provide depth for their postseason run. While primarily serving as a designated hitter, the player appeared in 37 games for New York and was part of the roster that defeated the New York Mets to win the 2000 World Series. This stint marked the final championship ring of the player&#x27;s career.">What was the role of this player during the 2000 season with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Yes, this occurred on May 26, 1993, during a game between the Texas Rangers and the Cleveland Indians. A fly ball hit by Carlos Martinez struck the top of the player&#x27;s head in right field and deflected over the wall for a home run. The bizarre play remains one of the most famous blooper highlights in baseball history.">Is it true that a fly ball once bounced off this player&#x27;s head for a home run?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>42.4</td><td>7057</td><td>1877</td><td>462</td><td>.266</td><td>1186</td><td>1407</td><td>200</td><td>.353</td><td>.515</td><td>.867</td><td>132</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-08.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of José Canseco" src="images/answer-2026-04-08.webp"/>
+</div>
+<div class="player-info">
+<h2>José Canseco "The Chemist"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Became the first player in Major League Baseball history to join the 40-40 club during the 1988 season.</li>
+<li>Earned the 1986 American League Rookie of the Year award and the 1988 American League Most Valuable Player award.</li>
+<li>Won two World Series championships, one with the Oakland Athletics in 1989 and one with the New York Yankees in 2000.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about José Canseco?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="As a central figure of the 'Bash Brothers' era, this player revolutionized the game by combining elite power with stolen-base speed. This unique skill set led to the first 40-40 season in history and helped the Oakland Athletics reach three consecutive World Series from 1988 to 1990. The player finished a 17-year career with 462 home runs and 200 stolen bases.">How would you summarize the overall impact of this player on the game during the late 1980s?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="The Yankees acquired the veteran slugger off waivers from the Tampa Bay Devil Rays in August 2000 to provide depth for their postseason run. While primarily serving as a designated hitter, the player appeared in 37 games for New York and was part of the roster that defeated the New York Mets to win the 2000 World Series. This stint marked the final championship ring of the player's career.">What was the role of this player during the 2000 season with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Yes, this occurred on May 26, 1993, during a game between the Texas Rangers and the Cleveland Indians. A fly ball hit by Carlos Martinez struck the top of the player's head in right field and deflected over the wall for a home run. The bizarre play remains one of the most famous blooper highlights in baseball history.">Is it true that a fly ball once bounced off this player's head for a home run?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>42.4</td><td>7057</td><td>1877</td><td>462</td><td>.266</td><td>1186</td><td>1407</td><td>200</td><td>.353</td><td>.515</td><td>.867</td><td>132</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-08.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1985", "1986", "1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001"];
             const warData = [0.4, 3.0, 1.6, 7.3, 2.2, 5.4, 5.3, 2.3, 0.1, 3.0, 2.6, 3.0, 0.2, 1.5, 2.7, 1.1, 0.8];
             const teamsByYear = ["OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "2TM", "TEX", "TEX", "BOS", "BOS", "OAK", "TOR", "TBD", "2TM", "CHW"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["OAK", "TOR", "CHW", "NYY", "TBD", "BOS", "TEX"], "years": ["1987", "1996", "2001", "1988", "1999", "1994", "1993", "1989", "1990", "1997", "1992", "1995", "1998", "2000", "1985", "1986", "1991"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Jos\u00e9 Canseco", "nickname": "The Chemist", "hints": ["Became the first player in Major League Baseball history to join the 40-40 club during the 1988 season.", "Earned the 1986 American League Rookie of the Year award and the 1988 American League Most Valuable Player award.", "Won two World Series championships, one with the Oakland Athletics in 1989 and one with the New York Yankees in 2000."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["OAK", "TOR", "CHW", "NYY", "TBD", "BOS", "TEX"], "years": ["1987", "1996", "2001", "1988", "1999", "1994", "1993", "1989", "1990", "1997", "1992", "1995", "1998", "2000", "1985", "1986", "1991"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Jos\u00e9 Canseco", "nickname": "The Chemist", "hints": ["Became the first player in Major League Baseball history to join the 40-40 club during the 1988 season.", "Earned the 1986 American League Rookie of the Year award and the 1988 American League Most Valuable Player award.", "Won two World Series championships, one with the Oakland Athletics in 1989 and one with the New York Yankees in 2000."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 08-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 08-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-09.html
+++ b/2026-04-09.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-09 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-09">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Randy Velarde.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 09, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-09.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 09, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-09.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-09" rel="canonical"/><meta content="Discover the career highlights and statistics for Randy Velarde, the featured New York Yankee for the 2026-04-09 trivia puzzle." name="description"/>
+<title>Answer for 2026-04-09 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 09, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-09.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 09, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-09.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 09, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 09, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-09.webp" alt="Photo of Randy Velarde">
-                    </div>
-                    <div class="player-info">
-                        <h2>Randy Velarde</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Recorded an unassisted triple play against the New York Yankees in 2000.</li>
-                        <li>Played for four different American League teams over a 16-season career.</li>
-                        <li>Achieved a career batting average of .276 while serving primarily as a versatile utility infielder.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Randy Velarde?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A reliable utility player, the infielder spent the majority of a 16-year career providing defensive flexibility and consistent contact hitting. Originally drafted by the Chicago White Sox, the player became a key contributor for the New York Yankees and later the Oakland Athletics. Over 1,300 career games, the player maintained a solid .354 on-base percentage.">How would you summarize the overall career trajectory of this versatile infielder?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="During the 1995 American League Division Series against the Seattle Mariners, the player delivered a memorable performance. In Game 2, a crucial three-run home run helped propel the Yankees to a victory. This contribution remains a highlight of the player&#x27;s postseason tenure in pinstripes.">What was a standout moment for this player during his tenure with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="On May 29, 2000, while playing for the Oakland Athletics, the player turned an unassisted triple play against the New York Yankees. This rare defensive feat occurred in the sixth inning when the player caught a line drive, stepped on second base, and tagged the runner coming from first. It remains one of the rarest defensive plays in Major League Baseball history.">Is there any unusual or quirky statistical achievement associated with this player&#x27;s time in the field?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>24.9</td><td>4244</td><td>1171</td><td>100</td><td>.276</td><td>633</td><td>445</td><td>78</td><td>.352</td><td>.408</td><td>.760</td><td>101</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-09.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Randy Velarde" src="images/answer-2026-04-09.webp"/>
+</div>
+<div class="player-info">
+<h2>Randy Velarde</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Recorded an unassisted triple play against the New York Yankees in 2000.</li>
+<li>Played for four different American League teams over a 16-season career.</li>
+<li>Achieved a career batting average of .276 while serving primarily as a versatile utility infielder.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Randy Velarde?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="A reliable utility player, the infielder spent the majority of a 16-year career providing defensive flexibility and consistent contact hitting. Originally drafted by the Chicago White Sox, the player became a key contributor for the New York Yankees and later the Oakland Athletics. Over 1,300 career games, the player maintained a solid .354 on-base percentage.">How would you summarize the overall career trajectory of this versatile infielder?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During the 1995 American League Division Series against the Seattle Mariners, the player delivered a memorable performance. In Game 2, a crucial three-run home run helped propel the Yankees to a victory. This contribution remains a highlight of the player's postseason tenure in pinstripes.">What was a standout moment for this player during his tenure with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="On May 29, 2000, while playing for the Oakland Athletics, the player turned an unassisted triple play against the New York Yankees. This rare defensive feat occurred in the sixth inning when the player caught a line drive, stepped on second base, and tagged the runner coming from first. It remains one of the rarest defensive plays in Major League Baseball history.">Is there any unusual or quirky statistical achievement associated with this player's time in the field?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>24.9</td><td>4244</td><td>1171</td><td>100</td><td>.276</td><td>633</td><td>445</td><td>78</td><td>.352</td><td>.408</td><td>.760</td><td>101</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-09.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1987", "1988", "1989", "1990", "1991", "1992", "1993", "1994", "1995", "1996", "1997", "1998", "1999", "2000", "2001", "2002"];
             const warData = [-0.2, -0.4, 1.9, 1.4, 0.3, 1.8, 2.0, 1.1, 3.5, 2.1, 0.0, 0.5, 7.0, 2.3, 1.9, -0.2];
             const teamsByYear = ["NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "NYY", "CAL", "ANA", "ANA", "2TM", "OAK", "2TM", "OAK"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["CAL", "NYY", "OAK", "ANA", "TEX"], "years": ["1990", "1988", "1994", "2000", "2001", "1992", "1989", "1995", "1991", "1998", "2002", "1987", "1996", "1999", "1997", "1993"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Randy Velarde", "nickname": "", "hints": ["Recorded an unassisted triple play against the New York Yankees in 2000.", "Played for four different American League teams over a 16-season career.", "Achieved a career batting average of .276 while serving primarily as a versatile utility infielder."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["CAL", "NYY", "OAK", "ANA", "TEX"], "years": ["1990", "1988", "1994", "2000", "2001", "1992", "1989", "1995", "1991", "1998", "2002", "1987", "1996", "1999", "1997", "1993"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Randy Velarde", "nickname": "", "hints": ["Recorded an unassisted triple play against the New York Yankees in 2000.", "Played for four different American League teams over a 16-season career.", "Achieved a career batting average of .276 while serving primarily as a versatile utility infielder."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 09-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 09-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-10.html
+++ b/2026-04-10.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-10 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-10">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Bubba Trammell.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 10, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-10.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 10, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-10.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-10" rel="canonical"/><meta content="Discover the career highlights and statistics for Bubba Trammell, the featured New York Yankee for the 2026-04-10 trivia puzzle." name="description"/>
+<title>Answer for 2026-04-10 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 10, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-10.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 10, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-10.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 10, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 10, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-10.webp" alt="Photo of Bubba Trammell">
-                    </div>
-                    <div class="player-info">
-                        <h2>Bubba Trammell</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Selected in the 28th round of the 1994 MLB draft by the Detroit Tigers.</li>
-                        <li>Recorded a career-high 25 home runs during the 2000 season with the Tampa Bay Devil Rays.</li>
-                        <li>Appeared in the 2000 World Series as a member of the New York Mets.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Bubba Trammell?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The career spanned seven seasons across five different major league franchises, primarily serving as a corner outfielder and designated hitter. While never an All-Star, the player provided consistent power, finishing with 82 career home runs. The most productive offensive stretch occurred between 1999 and 2000 while playing for the Tigers and Devil Rays.">How would you summarize the overall career trajectory of this outfielder?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Acquired from the San Diego Padres in July 2003, the tenure with the Yankees lasted only 23 games. Despite the limited time, the player contributed to a division-winning team before being released in August. This move served as a depth acquisition during a season where the club ultimately reached the World Series.">What was the significance of the brief stint with the New York Yankees in 2003?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Before reaching the major leagues, the player attended the University of Tennessee. During the 1994 collegiate season, the team reached the College World Series, providing a high-pressure environment that helped prepare for a professional career. This collegiate experience was a key stepping stone before being drafted by the Detroit Tigers.">Is there any interesting background regarding the path to professional baseball?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>4.2</td><td>1798</td><td>469</td><td>82</td><td>.261</td><td>243</td><td>285</td><td>10</td><td>.339</td><td>.459</td><td>.798</td><td>109</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-10.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Bubba Trammell" src="images/answer-2026-04-10.webp"/>
+</div>
+<div class="player-info">
+<h2>Bubba Trammell</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Selected in the 28th round of the 1994 MLB draft by the Detroit Tigers.</li>
+<li>Recorded a career-high 25 home runs during the 2000 season with the Tampa Bay Devil Rays.</li>
+<li>Appeared in the 2000 World Series as a member of the New York Mets.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Bubba Trammell?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The career spanned seven seasons across five different major league franchises, primarily serving as a corner outfielder and designated hitter. While never an All-Star, the player provided consistent power, finishing with 82 career home runs. The most productive offensive stretch occurred between 1999 and 2000 while playing for the Tigers and Devil Rays.">How would you summarize the overall career trajectory of this outfielder?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Acquired from the San Diego Padres in July 2003, the tenure with the Yankees lasted only 23 games. Despite the limited time, the player contributed to a division-winning team before being released in August. This move served as a depth acquisition during a season where the club ultimately reached the World Series.">What was the significance of the brief stint with the New York Yankees in 2003?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Before reaching the major leagues, the player attended the University of Tennessee. During the 1994 collegiate season, the team reached the College World Series, providing a high-pressure environment that helped prepare for a professional career. This collegiate experience was a key stepping stone before being drafted by the Detroit Tigers.">Is there any interesting background regarding the path to professional baseball?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>4.2</td><td>1798</td><td>469</td><td>82</td><td>.261</td><td>243</td><td>285</td><td>10</td><td>.339</td><td>.459</td><td>.798</td><td>109</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-10.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1997", "1998", "1999", "2000", "2001", "2002", "2003"];
             const warData = [-0.5, 1.1, 1.4, 0.3, 2.2, -0.2, -0.1];
             const teamsByYear = ["DET", "TBD", "TBD", "2TM", "SDP", "SDP", "NYY"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["NYM", "DET", "TBD", "SDP", "NYY"], "years": ["2002", "2001", "2003", "1997", "1999", "1998", "2000"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Bubba Trammell", "nickname": "", "hints": ["Selected in the 28th round of the 1994 MLB draft by the Detroit Tigers.", "Recorded a career-high 25 home runs during the 2000 season with the Tampa Bay Devil Rays.", "Appeared in the 2000 World Series as a member of the New York Mets."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["NYM", "DET", "TBD", "SDP", "NYY"], "years": ["2002", "2001", "2003", "1997", "1999", "1998", "2000"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Bubba Trammell", "nickname": "", "hints": ["Selected in the 28th round of the 1994 MLB draft by the Detroit Tigers.", "Recorded a career-high 25 home runs during the 2000 season with the Tampa Bay Devil Rays.", "Appeared in the 2000 World Series as a member of the New York Mets."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 11-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 11-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-12.html
+++ b/2026-04-12.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-12 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-12">
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Shelley Duncan.">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta property="og:title" content="Name That Yankee - April 12, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-12.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 12, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-12.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-12" rel="canonical"/><meta content='Discover the career highlights and statistics for Shelley Duncan "Shelley", the featured New York Yankee for the 2026-04-12 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-12 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+
+<!-- Meta tags for better social sharing -->
+<meta content="Name That Yankee - April 12, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-12.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 12, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-12.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 12, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 12, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-12.webp" alt="Photo of Shelley Duncan">
-                    </div>
-                    <div class="player-info">
-                        <h2>Shelley Duncan "Shelley"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Selected by the New York Yankees in the second round of the 2001 MLB Draft.</li>
-                        <li>Recorded a multi-homer game in only the fourth major league appearance.</li>
-                        <li>Son of former major league pitcher Dave Duncan and brother of former major league outfielder Chris Duncan.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Shelley Duncan?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="The career spanned seven seasons in Major League Baseball, primarily serving as a corner outfielder and designated hitter. After spending the first three years with the New York Yankees, time was also spent with the Cleveland Indians and Tampa Bay Rays. The professional journey concluded with a career slash line of .229/.306/.423 across 448 games.">How would you summarize the professional career trajectory of this player?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A significant highlight occurred in 2007 when a hot streak helped the Yankees secure a Wild Card berth. During that stretch, a memorable home run was hit against the Boston Red Sox at Fenway Park, which became a defining moment of that season&#x27;s rivalry. Overall, the 2007 campaign saw seven home runs and 21 RBIs in just 35 games played.">What was a standout moment during the tenure with the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="After retiring from professional play, a transition into coaching and management began within the Arizona Diamondbacks organization. Roles included managing the Reno Aces, the Triple-A affiliate of the Diamondbacks, for several seasons. This path allowed for the continued development of young talent within the professional ranks.">What did the post-playing career look like for this individual?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>1.0</td><td>885</td><td>200</td><td>43</td><td>.226</td><td>117</td><td>144</td><td>2</td><td>.305</td><td>.419</td><td>.724</td><td>99</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-12.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Shelley Duncan" src="images/answer-2026-04-12.webp"/>
+</div>
+<div class="player-info">
+<h2>Shelley Duncan "Shelley"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Selected by the New York Yankees in the second round of the 2001 MLB Draft.</li>
+<li>Recorded a multi-homer game in only the fourth major league appearance.</li>
+<li>Son of former major league pitcher Dave Duncan and brother of former major league outfielder Chris Duncan.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Shelley Duncan?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="The career spanned seven seasons in Major League Baseball, primarily serving as a corner outfielder and designated hitter. After spending the first three years with the New York Yankees, time was also spent with the Cleveland Indians and Tampa Bay Rays. The professional journey concluded with a career slash line of .229/.306/.423 across 448 games.">How would you summarize the professional career trajectory of this player?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="A significant highlight occurred in 2007 when a hot streak helped the Yankees secure a Wild Card berth. During that stretch, a memorable home run was hit against the Boston Red Sox at Fenway Park, which became a defining moment of that season's rivalry. Overall, the 2007 campaign saw seven home runs and 21 RBIs in just 35 games played.">What was a standout moment during the tenure with the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring from professional play, a transition into coaching and management began within the Arizona Diamondbacks organization. Roles included managing the Reno Aces, the Triple-A affiliate of the Diamondbacks, for several seasons. This path allowed for the continued development of young talent within the professional ranks.">What did the post-playing career look like for this individual?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>1.0</td><td>885</td><td>200</td><td>43</td><td>.226</td><td>117</td><td>144</td><td>2</td><td>.305</td><td>.419</td><td>.724</td><td>99</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-12.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["2007", "2008", "2009", "2010", "2011", "2012", "2013"];
             const warData = [0.5, -0.3, -0.2, 1.2, 0.6, -0.4, -0.3];
             const teamsByYear = ["NYY", "NYY", "NYY", "CLE", "CLE", "CLE", "TBR"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["CLE", "NYY", "TBR"], "years": ["2010", "2011", "2013", "2007", "2012", "2008", "2009"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Shelley Duncan", "nickname": "Shelley", "hints": ["Selected by the New York Yankees in the second round of the 2001 MLB Draft.", "Recorded a multi-homer game in only the fourth major league appearance.", "Son of former major league pitcher Dave Duncan and brother of former major league outfielder Chris Duncan."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["CLE", "NYY", "TBR"], "years": ["2010", "2011", "2013", "2007", "2012", "2008", "2009"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Shelley Duncan", "nickname": "Shelley", "hints": ["Selected by the New York Yankees in the second round of the 2001 MLB Draft.", "Recorded a multi-homer game in only the fourth major league appearance.", "Son of former major league pitcher Dave Duncan and brother of former major league outfielder Chris Duncan."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 12-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 12-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-13.html
+++ b/2026-04-13.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-13 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-13">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Reggie Jackson.">
-    <meta property="og:title" content="Name That Yankee - April 13, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-13.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 13, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-13.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-13" rel="canonical"/><meta content='Discover the career highlights and statistics for Reggie Jackson "Mr. October", the featured New York Yankee for the 2026-04-13 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-13 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+<!-- Meta tags for better social sharing -->
+
+<meta content="Name That Yankee - April 13, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-13.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 13, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-13.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 13, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 13, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-13.webp" alt="Photo of Reggie Jackson">
-                    </div>
-                    <div class="player-info">
-                        <h2>Reggie Jackson "Mr. October"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Earned the nickname Mr. October for exceptional postseason power hitting.</li>
-                        <li>Won five World Series championships across stints with the Oakland Athletics and New York Yankees.</li>
-                        <li>Became the first player in Major League Baseball history to hit three home runs in a single World Series game.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Reggie Jackson?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A 14-time All-Star and the 1973 American League MVP, this slugger finished a 21-season career with 563 home runs. Beyond the statistics, a flair for the dramatic in high-pressure situations cemented a reputation as one of the most clutch hitters in baseball history. Induction into the National Baseball Hall of Fame occurred in 1993 on the first ballot.">How would you summarize the overall impact of this player on the game?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="In the clinching Game 6 against the Los Angeles Dodgers, three consecutive swings resulted in three home runs on three pitches from three different pitchers. This performance secured the World Series MVP award and remains one of the most iconic individual displays in postseason history. It solidified a legacy as the primary catalyst for the Yankees&#x27; back-to-back titles in 1977 and 1978.">What defined the legendary performance during the 1977 World Series?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="Known for an outspoken and confident personality, a famous 1977 interview with Sport magazine famously labeled the team a &#x27;candy bar&#x27; because of the internal friction between star players and management. This brashness often made for colorful headlines, but it also reflected a deep-seated desire to be the focal point of the game&#x27;s biggest moments. Off the field, a lifelong passion for collecting and restoring classic cars has remained a significant personal pursuit.">Is there a notable off-field story or personality trait associated with this player?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>74.1</td><td>9864</td><td>2584</td><td>563</td><td>.262</td><td>1551</td><td>1702</td><td>228</td><td>.356</td><td>.490</td><td>.846</td><td>139</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-13.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Reggie Jackson" src="images/answer-2026-04-13.webp"/>
+</div>
+<div class="player-info">
+<h2>Reggie Jackson "Mr. October"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Earned the nickname Mr. October for exceptional postseason power hitting.</li>
+<li>Won five World Series championships across stints with the Oakland Athletics and New York Yankees.</li>
+<li>Became the first player in Major League Baseball history to hit three home runs in a single World Series game.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Reggie Jackson?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="A 14-time All-Star and the 1973 American League MVP, this slugger finished a 21-season career with 563 home runs. Beyond the statistics, a flair for the dramatic in high-pressure situations cemented a reputation as one of the most clutch hitters in baseball history. Induction into the National Baseball Hall of Fame occurred in 1993 on the first ballot.">How would you summarize the overall impact of this player on the game?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="In the clinching Game 6 against the Los Angeles Dodgers, three consecutive swings resulted in three home runs on three pitches from three different pitchers. This performance secured the World Series MVP award and remains one of the most iconic individual displays in postseason history. It solidified a legacy as the primary catalyst for the Yankees' back-to-back titles in 1977 and 1978.">What defined the legendary performance during the 1977 World Series?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="Known for an outspoken and confident personality, a famous 1977 interview with Sport magazine famously labeled the team a 'candy bar' because of the internal friction between star players and management. This brashness often made for colorful headlines, but it also reflected a deep-seated desire to be the focal point of the game's biggest moments. Off the field, a lifelong passion for collecting and restoring classic cars has remained a significant personal pursuit.">Is there a notable off-field story or personality trait associated with this player?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>74.1</td><td>9864</td><td>2584</td><td>563</td><td>.262</td><td>1551</td><td>1702</td><td>228</td><td>.356</td><td>.490</td><td>.846</td><td>139</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-13.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1967", "1968", "1969", "1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987"];
             const warData = [-0.5, 5.3, 9.3, 2.2, 6.4, 5.6, 7.8, 5.7, 6.7, 5.3, 4.5, 3.5, 3.5, 4.8, 1.0, 3.1, -1.8, -0.2, 1.1, 1.2, -0.4];
             const teamsByYear = ["KCA", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "OAK", "BAL", "NYY", "NYY", "NYY", "NYY", "NYY", "CAL", "CAL", "CAL", "CAL", "CAL", "OAK"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["NYY", "KCA", "CAL", "OAK", "BAL"], "years": ["1974", "1984", "1971", "1981", "1967", "1978", "1979", "1972", "1987", "1982", "1970", "1968", "1977", "1973", "1986", "1976", "1985", "1983", "1980", "1975", "1969"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Reggie Jackson", "nickname": "Mr. October", "hints": ["Earned the nickname Mr. October for exceptional postseason power hitting.", "Won five World Series championships across stints with the Oakland Athletics and New York Yankees.", "Became the first player in Major League Baseball history to hit three home runs in a single World Series game."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["NYY", "KCA", "CAL", "OAK", "BAL"], "years": ["1974", "1984", "1971", "1981", "1967", "1978", "1979", "1972", "1987", "1982", "1970", "1968", "1977", "1973", "1986", "1976", "1985", "1983", "1980", "1975", "1969"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Reggie Jackson", "nickname": "Mr. October", "hints": ["Earned the nickname Mr. October for exceptional postseason power hitting.", "Won five World Series championships across stints with the Oakland Athletics and New York Yankees.", "Became the first player in Major League Baseball history to hit three home runs in a single World Series game."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 13-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 13-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/2026-04-14.html
+++ b/2026-04-14.html
@@ -1,31 +1,28 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for 2026-04-14 | Name That Yankee</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="manifest" href="manifest.json">
-    <link rel="shortcut icon" type="image/png" href="images/favicon.png">
-    <link rel="apple-touch-icon" sizes="180x180" href="apple-touch-icon.png">
-    <link rel="canonical" href="https://namethatyankeequiz.com/2026-04-14">
-    
-    <!-- Meta tags for better social sharing -->
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is Don Baylor.">
-    <meta property="og:title" content="Name That Yankee - April 14, 2026">
-    <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta property="og:type" content="website">
-    <meta property="og:site_name" content="Name That Yankee">
-    <meta property="og:image" content="images/clue-2026-04-14.webp">
-    
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Name That Yankee - April 14, 2026">
-    <meta name="twitter:description" content="Can you name this New York Yankee based on their career stats?">
-    <meta name="twitter:image" content="images/clue-2026-04-14.webp">
-    
-    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0" name="viewport"/><link href="https://namethatyankeequiz.com/2026-04-14" rel="canonical"/><meta content='Discover the career highlights and statistics for Don Baylor "Groove", the featured New York Yankee for the 2026-04-14 trivia puzzle.' name="description"/>
+<title>Answer for 2026-04-14 | Name That Yankee</title>
+<link href="style.css" rel="stylesheet"/>
+<link href="manifest.json" rel="manifest"/>
+<link href="images/favicon.png" rel="shortcut icon" type="image/png"/>
+<link href="apple-touch-icon.png" rel="apple-touch-icon" sizes="180x180"/>
 
-    <script type="application/ld+json">
+<!-- Meta tags for better social sharing -->
+
+<meta content="Name That Yankee - April 14, 2026" property="og:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" property="og:description"/>
+<meta content="website" property="og:type"/>
+<meta content="Name That Yankee" property="og:site_name"/>
+<meta content="images/clue-2026-04-14.webp" property="og:image"/>
+<meta content="summary_large_image" name="twitter:card"/>
+<meta content="Name That Yankee - April 14, 2026" name="twitter:title"/>
+<meta content="Can you name this New York Yankee based on their career stats?" name="twitter:description"/>
+<meta content="images/clue-2026-04-14.webp" name="twitter:image"/>
+<meta content="NameThatYankee" name="apple-mobile-web-app-title"/>
+<script type="application/ld+json">
     {
       "@context": "https://schema.org",
       "@type": "Article",
@@ -49,107 +46,93 @@
     </script>
 </head>
 <body>
-    <header>
-        <div class="header-content">
-            <h1>The answer for April 14, 2026 is...</h1>
-        </div>
-        <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
-            <div id="score-display">
+<header>
+<div class="header-content">
+<h1>The answer for April 14, 2026 is...</h1>
+</div>
+<div class="header-controls">
+<a class="instructions-link" href="instructions">New Features!</a>
+<div id="score-display">
                 Your Score: <span id="total-score">0</span>
-                <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
-                <div id="score-breakdown-container" style="display: none;">
-                    <div class="breakdown-header">Score Breakdown</div>
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Clue</th>
-                                <th>Points</th>
-                                <th>Count</th>
-                            </tr>
-                        </thead>
-                        <tbody id="breakdown-body"></tbody>
-                    </table>
-                </div>
-            </div>
-        </div>
-    </header>
-
-    <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
-
-        <div class="detail-layout">
-            <div class="left-column">
-                <div class="player-profile">
-                    <div class="player-photo">
-                        <img src="images/answer-2026-04-14.webp" alt="Photo of Don Baylor">
-                    </div>
-                    <div class="player-info">
-                        <h2>Don Baylor "Groove"</h2>
-                        <div class="facts-header">
-                            <h3>Career Highlights & Facts</h3>
-                            <p class="disclaimer">(Facts are AI-generated and may require verification)</p>
-                        </div>
-                        <ul>
-                        <li>Won the 1979 American League Most Valuable Player award while playing for the California Angels.</li>
-                        <li>Led the American League in hit-by-pitches during eight different seasons.</li>
-                        <li>Appeared in three consecutive World Series with three different teams from 1986 to 1988.</li>
-                        </ul>
-
-                <div class="followup-section" id="followup-section">
-                    <h3>Would you like to find out more about Don Baylor?</h3>
-                    <div class="followup-buttons">
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="A versatile slugger, this player spent 19 seasons in the majors and was known for a gritty, team-first approach. Beyond the 1979 MVP award, the career included over 2,000 hits and 300 home runs. The transition from a star outfielder to a dedicated designated hitter allowed for sustained production well into the late 1980s.">How would you summarize the overall impact of this player&#x27;s long career?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="During the 1985 season with the Yankees, the veteran provided significant power by hitting 23 home runs and driving in 91 runs. The leadership provided in the clubhouse was highly regarded by teammates and management alike. This tenure helped solidify a reputation as a reliable run producer in high-pressure environments.">What was a notable contribution during the time spent playing for the New York Yankees?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-
-                        <div class="followup-item">
-                            <button class="followup-btn" data-answer="After retiring as a player, a successful transition into coaching and management occurred, including a stint as the manager of the Colorado Rockies. Notably, the 1995 season resulted in a National League Manager of the Year award after leading the expansion franchise to the postseason. This second act in baseball proved that the deep understanding of the game translated effectively from the batter&#x27;s box to the dugout.">Did this player have any notable experiences outside of being a professional athlete?</button>
-                            <div class="followup-answer" style="display:none;"></div>
-                        </div>
-            
-                    </div>
-                </div>
-            
-                    </div>
-                </div>
-                
-        <div class="stats-table-container">
-            <h3>Career Totals</h3>
-            <div class="table-wrapper">
-                <table>
-                    <thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
-                    <tbody><tr><td>28.5</td><td>8198</td><td>2135</td><td>338</td><td>.260</td><td>1236</td><td>1276</td><td>285</td><td>.342</td><td>.436</td><td>.777</td><td>118</td></tr></tbody>
-                </table>
-            </div>
-            <p class="citation">Statistics via Baseball-Reference.com</p>
-        </div>
-        
-            </div>
-            <div class="right-column">
-                <div class="original-card">
-                    <h3>The Original Clue</h3>
-                    <img src="images/clue-2026-04-14.webp" alt="Original trivia card">
-                </div>
-                
-        <div class="chart-container">
-            <h3>Career Arc by WAR</h3>
-            <div class="chart-wrapper">
-                <canvas id="careerArcChart"></canvas>
-            </div>
-        </div>
-
-        <script src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" crossorigin="anonymous"></script>
-        <script>
+<svg aria-hidden="true" class="chevron-icon" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg"><polyline points="6 9 12 15 18 9"></polyline></svg>
+<div id="score-breakdown-container" style="display: none;">
+<div class="breakdown-header">Score Breakdown</div>
+<table>
+<thead>
+<tr>
+<th>Clue</th>
+<th>Points</th>
+<th>Count</th>
+</tr>
+</thead>
+<tbody id="breakdown-body"></tbody>
+</table>
+</div>
+</div>
+</div>
+</header>
+<main>
+<a class="back-link" href="index">← Back to All Questions</a>
+<div class="detail-layout">
+<div class="left-column">
+<div class="player-profile">
+<div class="player-photo">
+<img alt="Photo of Don Baylor" src="images/answer-2026-04-14.webp"/>
+</div>
+<div class="player-info">
+<h2>Don Baylor "Groove"</h2>
+<div class="facts-header">
+<h3>Career Highlights &amp; Facts</h3>
+<p class="disclaimer">(Facts are AI-generated and may require verification)</p>
+</div>
+<ul>
+<li>Won the 1979 American League Most Valuable Player award while playing for the California Angels.</li>
+<li>Led the American League in hit-by-pitches during eight different seasons.</li>
+<li>Appeared in three consecutive World Series with three different teams from 1986 to 1988.</li>
+</ul>
+<div class="followup-section" id="followup-section">
+<h3>Would you like to find out more about Don Baylor?</h3>
+<div class="followup-buttons">
+<div class="followup-item">
+<button class="followup-btn" data-answer="A versatile slugger, this player spent 19 seasons in the majors and was known for a gritty, team-first approach. Beyond the 1979 MVP award, the career included over 2,000 hits and 300 home runs. The transition from a star outfielder to a dedicated designated hitter allowed for sustained production well into the late 1980s.">How would you summarize the overall impact of this player's long career?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="During the 1985 season with the Yankees, the veteran provided significant power by hitting 23 home runs and driving in 91 runs. The leadership provided in the clubhouse was highly regarded by teammates and management alike. This tenure helped solidify a reputation as a reliable run producer in high-pressure environments.">What was a notable contribution during the time spent playing for the New York Yankees?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+<div class="followup-item">
+<button class="followup-btn" data-answer="After retiring as a player, a successful transition into coaching and management occurred, including a stint as the manager of the Colorado Rockies. Notably, the 1995 season resulted in a National League Manager of the Year award after leading the expansion franchise to the postseason. This second act in baseball proved that the deep understanding of the game translated effectively from the batter's box to the dugout.">Did this player have any notable experiences outside of being a professional athlete?</button>
+<div class="followup-answer" style="display:none;"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="stats-table-container">
+<h3>Career Totals</h3>
+<div class="table-wrapper">
+<table>
+<thead><tr><th>WAR</th><th>AB</th><th>H</th><th>HR</th><th>BA</th><th>R</th><th>RBI</th><th>SB</th><th>OBP</th><th>SLG</th><th>OPS</th><th>OPS+</th></tr></thead>
+<tbody><tr><td>28.5</td><td>8198</td><td>2135</td><td>338</td><td>.260</td><td>1236</td><td>1276</td><td>285</td><td>.342</td><td>.436</td><td>.777</td><td>118</td></tr></tbody>
+</table>
+</div>
+<p class="citation">Statistics via Baseball-Reference.com</p>
+</div>
+</div>
+<div class="right-column">
+<div class="original-card">
+<h3>The Original Clue</h3>
+<img alt="Original trivia card" src="images/clue-2026-04-14.webp"/>
+</div>
+<div class="chart-container">
+<h3>Career Arc by WAR</h3>
+<div class="chart-wrapper">
+<canvas id="careerArcChart"></canvas>
+</div>
+</div>
+<script crossorigin="anonymous" integrity="sha384-jb8JQMbMoBUzgWatfe6COACi2ljcDdZQ2OxczGA3bGNeWe+6DChMTBJemed7ZnvJ" src="https://cdn.jsdelivr.net/npm/chart.js@4.5.1"></script>
+<script>
             const years = ["1970", "1971", "1972", "1973", "1974", "1975", "1976", "1977", "1978", "1979", "1980", "1981", "1982", "1983", "1984", "1985", "1986", "1987", "1988"];
             const warData = [0.0, 0.2, 2.2, 3.3, 1.8, 3.0, 2.9, 0.4, 1.6, 3.7, -1.5, 1.4, 0.6, 3.5, 3.0, 0.7, 1.6, 0.4, -0.3];
             const teamsByYear = ["BAL", "BAL", "BAL", "BAL", "BAL", "BAL", "OAK", "CAL", "CAL", "CAL", "CAL", "CAL", "CAL", "NYY", "NYY", "NYY", "BOS", "2TM", "OAK"];
@@ -270,14 +253,13 @@
                 }
             });
         </script>
-        
-            </div>
-        </div>
-        <div id="search-data" style="display:none;">{"teams": ["MIN", "CAL", "BOS", "BAL", "OAK", "NYY"], "years": ["1976", "1979", "1970", "1974", "1975", "1986", "1981", "1985", "1973", "1978", "1971", "1972", "1984", "1980", "1988", "1987", "1982", "1977", "1983"]}</div>
-        <div id="quiz-data" style="display:none;">{"answer": "Don Baylor", "nickname": "Groove", "hints": ["Won the 1979 American League Most Valuable Player award while playing for the California Angels.", "Led the American League in hit-by-pitches during eight different seasons.", "Appeared in three consecutive World Series with three different teams from 1986 to 1988."]}</div>
-    </main>
-    <script type="module" src="js/detail.js"></script>
-    <script>
+</div>
+</div>
+<div id="search-data" style="display:none;">{"teams": ["MIN", "CAL", "BOS", "BAL", "OAK", "NYY"], "years": ["1976", "1979", "1970", "1974", "1975", "1986", "1981", "1985", "1973", "1978", "1971", "1972", "1984", "1980", "1988", "1987", "1982", "1977", "1983"]}</div>
+<div id="quiz-data" style="display:none;">{"answer": "Don Baylor", "nickname": "Groove", "hints": ["Won the 1979 American League Most Valuable Player award while playing for the California Angels.", "Led the American League in hit-by-pitches during eight different seasons.", "Appeared in three consecutive World Series with three different teams from 1986 to 1988."]}</div>
+</main>
+<script src="js/detail.js" type="module"></script>
+<script>
     document.addEventListener('DOMContentLoaded', function() {
         const container = document.getElementById('followup-section');
         if (!container) return;
@@ -305,11 +287,11 @@
         });
     });
     </script>
-    <footer>
-		<p class="disclaimer-footer">
+<footer>
+<p class="disclaimer-footer">
 	        This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
 	    </p>
-        <p>Last Updated: 15-Apr-2026</p>
-    </footer>    
+<p>Last Updated: 15-Apr-2026</p>
+</footer>
 </body>
 </html>

--- a/analytics.html
+++ b/analytics.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/analytics.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/analytics">
     <title>Site Analytics - Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/x-icon" href="images/favicon.ico">
@@ -16,7 +16,7 @@
             <h1>Site Analytics</h1>
         </div>
         <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
+            <a href="instructions" class="instructions-link">New Features!</a>
             <div id="score-display">
                 Your Score: <span id="total-score">0</span>
                 <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -38,7 +38,7 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Puzzles</a>
+        <a href="./" class="back-link">← Back to All Puzzles</a>
 
         <div id="loading-message" class="text-center p-8">
             <p class="text-xl font-semibold">Loading analytics data...</p>

--- a/docs/superpowers/plans/2024-05-22-seo-cleanup-refactor.md
+++ b/docs/superpowers/plans/2024-05-22-seo-cleanup-refactor.md
@@ -1,0 +1,42 @@
+# SEO Cleanup Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refactor `seo_cleanup.py` to use `BeautifulSoup` for robust HTML manipulation, fix canonical URL formatting, and improve player name extraction.
+
+**Architecture:**
+- Use `BeautifulSoup` with `html.parser` for all HTML modifications.
+- Extract player name from `<title>` (various formats) or fallback to `<h2>`.
+- Canonical URL always uses the file's date stem (YYYY-MM-DD).
+- Normalize links using BeautifulSoup to replace `.html` extensions in internal links.
+
+**Tech Stack:** Python 3, BeautifulSoup4, Pytest
+
+---
+
+### Task 1: Update Tests for New Requirements
+
+**Files:**
+- Modify: `tests/test_seo_cleanup.py`
+
+- [ ] **Step 1: Update existing tests to reflect new requirements and add new ones for edge cases.**
+
+- [ ] **Step 2: Run tests to verify they fail with current implementation.**
+
+Run: `/Users/zagers/Documents/code/NameThatYankee/.worktrees/seo-finalization/.venv/bin/pytest tests/test_seo_cleanup.py -v`
+
+### Task 2: Refactor `seo_cleanup.py`
+
+**Files:**
+- Modify: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Refactor `extract_metadata` to use BeautifulSoup and handle 2026/fallback cases.**
+- [ ] **Step 2: Refactor `scrub_and_inject` to use BeautifulSoup.**
+- [ ] **Step 3: Refactor `normalize_links` to use BeautifulSoup.**
+- [ ] **Step 4: Update `process_file` and `main` to use BeautifulSoup and `pathlib`.**
+
+### Task 3: Execution and Verification
+
+- [ ] **Step 1: Run tests and ensure they pass.**
+- [ ] **Step 2: Run cleanup utility with `--no-dry-run`.**
+- [ ] **Step 3: Commit all changes.**

--- a/docs/superpowers/plans/2024-05-22-seo-cleanup.md
+++ b/docs/superpowers/plans/2024-05-22-seo-cleanup.md
@@ -1,0 +1,217 @@
+# SEO Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a one-time cleanup script to standardize metadata and URLs in all historical trivia HTML files.
+
+**Architecture:**
+- `page-generator/seo_cleanup.py` as a CLI utility.
+- Regex-based extraction of player name and date from `<title>`.
+- Regex-based removal and injection of `<meta>` and `<link>` tags.
+- Regex-based link normalization for internal `href` attributes.
+
+**Tech Stack:** Python 3, `pytest`.
+
+---
+
+### Task 1: Create `page-generator/seo_cleanup.py` skeleton and extraction logic
+
+**Files:**
+- Create: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Write `extract_metadata` function**
+
+```python
+import re
+
+def extract_metadata(html_content):
+    # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
+    match = re.search(r'<title>(.*?) Answer - (.*?) \| Name That Yankee</title>', html_content)
+    if match:
+        player_name = match.group(1).strip()
+        date = match.group(2).strip()
+        return player_name, date
+    return None, None
+```
+
+- [ ] **Step 2: Commit initial skeleton**
+
+```bash
+git add page-generator/seo_cleanup.py
+git commit -m "feat(seo): add extraction logic to seo_cleanup.py"
+```
+
+### Task 2: Implement scrubbing and injection logic
+
+**Files:**
+- Modify: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Write `scrub_and_inject` function**
+
+```python
+def scrub_and_inject(html_content, player_name, date):
+    # Remove existing description and canonical tags
+    html_content = re.sub(r'\s*<meta name="description" content=".*?">', '', html_content)
+    html_content = re.sub(r'\s*<link rel="canonical" href=".*?">', '', html_content)
+    
+    # Standardized tags
+    canonical_tag = f'\n    <link rel="canonical" href="https://namethatyankeequiz.com/{date}">'
+    description_tag = f'\n    <meta name="description" content="Discover the career highlights and statistics for {player_name}, the featured New York Yankee for the {date} trivia puzzle.">'
+    
+    # Inject after viewport tag
+    viewport_pattern = r'(<meta name="viewport" content=".*?">)'
+    if re.search(viewport_pattern, html_content):
+        new_tags = viewport_pattern + canonical_tag + description_tag
+        html_content = re.sub(viewport_pattern, r'\1' + canonical_tag + description_tag, html_content)
+        
+    return html_content
+```
+
+- [ ] **Step 2: Commit scrubbing logic**
+
+```bash
+git add page-generator/seo_cleanup.py
+git commit -m "feat(seo): add scrubbing and injection logic to seo_cleanup.py"
+```
+
+### Task 3: Implement link normalization logic
+
+**Files:**
+- Modify: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Write `normalize_links` function**
+
+```python
+def normalize_links(html_content):
+    # Replace href="YYYY-MM-DD.html" with href="YYYY-MM-DD"
+    # Matches href="2025-03-29.html" -> href="2025-03-29"
+    pattern = r'href="(\d{4}-\d{2}-\d{2})\.html"'
+    return re.sub(pattern, r'href="\1"', html_content)
+```
+
+- [ ] **Step 2: Commit link normalization**
+
+```bash
+git add page-generator/seo_cleanup.py
+git commit -m "feat(seo): add link normalization logic to seo_cleanup.py"
+```
+
+### Task 4: Complete CLI utility
+
+**Files:**
+- Modify: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Add CLI boilerplate**
+
+```python
+import os
+import glob
+import argparse
+
+def process_file(file_path, dry_run=True):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    player_name, date = extract_metadata(content)
+    if not player_name or not date:
+        print(f"Skipping {file_path}: Metadata not found")
+        return
+    
+    new_content = scrub_and_inject(content, player_name, date)
+    new_content = normalize_links(new_content)
+    
+    if content != new_content:
+        if dry_run:
+            print(f"[DRY RUN] Would update {file_path}")
+        else:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            print(f"Updated {file_path}")
+
+def main():
+    parser = argparse.ArgumentParser(description="SEO Cleanup Utility")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run", help="Apply changes")
+    parser.set_defaults(dry_run=True)
+    args = parser.parse_args()
+    
+    # Find YYYY-MM-DD.html files in the current root
+    html_files = glob.glob("????-??-??.html")
+    for file_path in html_files:
+        process_file(file_path, args.dry_run)
+
+if __name__ == "__main__":
+    main()
+```
+
+- [ ] **Step 2: Commit CLI utility**
+
+```bash
+git add page-generator/seo_cleanup.py
+git commit -m "feat(seo): complete seo_cleanup.py CLI utility"
+```
+
+### Task 5: Implement tests
+
+**Files:**
+- Create: `tests/test_seo_cleanup.py`
+
+- [ ] **Step 1: Write tests**
+
+```python
+import pytest
+from page_generator.seo_cleanup import extract_metadata, scrub_and_inject, normalize_links
+
+def test_extract_metadata():
+    html = "<title>Babe Ruth Answer - 2025-03-29 | Name That Yankee</title>"
+    name, date = extract_metadata(html)
+    assert name == "Babe Ruth"
+    assert date == "2025-03-29"
+
+def test_scrub_and_inject():
+    html = '<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<meta name="description" content="old">\n<link rel="canonical" href="old">'
+    name = "Babe Ruth"
+    date = "2025-03-29"
+    result = scrub_and_inject(html, name, date)
+    assert 'https://namethatyankeequiz.com/2025-03-29' in result
+    assert 'career highlights and statistics for Babe Ruth' in result
+    assert 'content="old"' not in result
+
+def test_normalize_links():
+    html = '<a href="2025-03-30.html">Next</a>'
+    result = normalize_links(html)
+    assert result == '<a href="2025-03-30">Next</a>'
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pytest tests/test_seo_cleanup.py
+```
+
+- [ ] **Step 3: Commit tests**
+
+```bash
+git add tests/test_seo_cleanup.py
+git commit -m "test(seo): add tests for seo_cleanup utility"
+```
+
+### Task 6: Execution and Verification
+
+- [ ] **Step 1: Perform dry run**
+
+```bash
+python3 page-generator/seo_cleanup.py --dry-run
+```
+
+- [ ] **Step 2: Perform final cleanup**
+
+```bash
+python3 page-generator/seo_cleanup.py --no-dry-run
+```
+
+- [ ] **Step 3: Commit all changed files**
+
+```bash
+git add *.html
+git commit -m "feat(seo): run batch cleanup on historical files"
+```

--- a/docs/superpowers/plans/2025-05-18-seo-cleanup-fix.md
+++ b/docs/superpowers/plans/2025-05-18-seo-cleanup-fix.md
@@ -1,0 +1,95 @@
+# SEO Cleanup Utility Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the SEO cleanup utility regex for multiline title tags, correct the test import path, and execute the cleanup on all historical pages.
+
+**Architecture:** 
+1. Update `page-generator/seo_cleanup.py` to handle multiline `<title>` tags using `re.DOTALL`.
+2. Update `tests/test_seo_cleanup.py` to correctly import from the hyphenated `page-generator` directory.
+3. Use a virtual environment to run `pytest`.
+4. Run the cleanup script first in dry-run mode, then in live mode.
+
+**Tech Stack:** Python 3, pytest, re
+
+---
+
+### Task 1: Fix Regex in `seo_cleanup.py`
+
+**Files:**
+- Modify: `page-generator/seo_cleanup.py`
+
+- [ ] **Step 1: Update `extract_metadata` regex**
+
+```python
+def extract_metadata(html_content):
+    # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
+    # Added re.DOTALL to handle multiline <title> tags
+    match = re.search(r'<title>\s*(.*?)\s*Answer - \s*(.*?)\s*\| Name That Yankee\s*</title>', html_content, re.DOTALL)
+    if match:
+        player_name = match.group(1).strip()
+        date = match.group(2).strip()
+        # Handle cases where there might be newlines inside the captured groups
+        player_name = " ".join(player_name.split())
+        date = " ".join(date.split())
+        return player_name, date
+    return None, None
+```
+
+- [ ] **Step 2: Commit script fix**
+
+```bash
+git add page-generator/seo_cleanup.py
+git commit -m "fix(seo): update title extraction regex to handle multiline tags"
+```
+
+### Task 2: Fix Imports in `tests/test_seo_cleanup.py`
+
+**Files:**
+- Modify: `tests/test_seo_cleanup.py`
+
+- [ ] **Step 1: Update import in `tests/test_seo_cleanup.py`**
+
+```python
+import pytest
+import sys
+import os
+
+# Add the project root to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Add page-generator to sys.path to allow importing from it directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'page-generator')))
+
+from seo_cleanup import extract_metadata, scrub_and_inject, normalize_links
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `/Users/zagers/Documents/code/NameThatYankee/venv_new/bin/python3 -m pytest tests/test_seo_cleanup.py`
+Expected: PASS
+
+- [ ] **Step 3: Commit test fix**
+
+```bash
+git add tests/test_seo_cleanup.py
+git commit -m "test(seo): fix import path for seo_cleanup utility"
+```
+
+### Task 3: Execute SEO Cleanup
+
+- [ ] **Step 1: Run dry-run**
+
+Run: `/Users/zagers/Documents/code/NameThatYankee/venv_new/bin/python3 page-generator/seo_cleanup.py --dry-run`
+Expected: Output showing files that would be updated.
+
+- [ ] **Step 2: Run live cleanup**
+
+Run: `/Users/zagers/Documents/code/NameThatYankee/venv_new/bin/python3 page-generator/seo_cleanup.py --no-dry-run`
+Expected: Output showing files updated.
+
+- [ ] **Step 3: Commit updated HTML files**
+
+```bash
+git add *.html
+git commit -m "chore(seo): apply batch metadata cleanup to all historical pages"
+```

--- a/index.html
+++ b/index.html
@@ -34,10 +34,10 @@
     </p>
    </div>
    <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+    <a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <a class="analytics-link" href="analytics.html">
+    <a class="analytics-link" href="analytics">
      📊 Site Analytics
     </a>
     <div id="score-display">
@@ -108,7 +108,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-14">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -142,7 +142,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-13">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -176,7 +176,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-12">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -210,7 +210,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-10">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -244,7 +244,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-09">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -278,7 +278,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-08">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -312,7 +312,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-07">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -346,7 +346,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-05">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -380,7 +380,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-04">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -414,7 +414,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-03">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -448,7 +448,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-01">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -482,7 +482,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-31">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -516,7 +516,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-30">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -550,7 +550,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-27">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -584,7 +584,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-22">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -618,7 +618,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-19">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -652,7 +652,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-18">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -686,7 +686,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-15">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -720,7 +720,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-11">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -754,7 +754,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-06">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -788,7 +788,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-05">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -822,7 +822,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-02-28">
+       <a class="action-link quiz-link" href="quiz?date=2026-02-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -856,7 +856,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -890,7 +890,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -924,7 +924,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -958,7 +958,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -992,7 +992,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1026,7 +1026,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1060,7 +1060,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1094,7 +1094,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1128,7 +1128,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1162,7 +1162,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1196,7 +1196,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1230,7 +1230,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1264,7 +1264,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1298,7 +1298,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1332,7 +1332,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1366,7 +1366,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1400,7 +1400,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1434,7 +1434,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1468,7 +1468,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1502,7 +1502,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1536,7 +1536,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1570,7 +1570,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-31">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1604,7 +1604,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1638,7 +1638,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1672,7 +1672,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1706,7 +1706,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1740,7 +1740,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1774,7 +1774,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1808,7 +1808,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1842,7 +1842,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1876,7 +1876,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1910,7 +1910,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1944,7 +1944,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1978,7 +1978,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2012,7 +2012,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2046,7 +2046,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2080,7 +2080,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2114,7 +2114,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2148,7 +2148,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2182,7 +2182,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2216,7 +2216,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2250,7 +2250,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2284,7 +2284,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2318,7 +2318,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2352,7 +2352,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2386,7 +2386,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-31">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2420,7 +2420,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2454,7 +2454,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2488,7 +2488,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2522,7 +2522,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2556,7 +2556,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2590,7 +2590,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2624,7 +2624,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2658,7 +2658,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2692,7 +2692,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2726,7 +2726,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2760,7 +2760,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2794,7 +2794,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2828,7 +2828,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2862,7 +2862,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2896,7 +2896,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2930,7 +2930,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2964,7 +2964,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-08">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2998,7 +2998,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3032,7 +3032,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3066,7 +3066,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3100,7 +3100,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3134,7 +3134,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3168,7 +3168,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3202,7 +3202,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3236,7 +3236,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3270,7 +3270,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3304,7 +3304,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3338,7 +3338,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3372,7 +3372,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3406,7 +3406,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3440,7 +3440,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3474,7 +3474,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3508,7 +3508,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3542,7 +3542,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3576,7 +3576,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3610,7 +3610,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3644,7 +3644,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3678,7 +3678,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3712,7 +3712,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3746,7 +3746,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3780,7 +3780,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3814,7 +3814,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3848,7 +3848,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3882,7 +3882,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3916,7 +3916,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3950,7 +3950,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3984,7 +3984,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4018,7 +4018,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4052,7 +4052,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4086,7 +4086,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4120,7 +4120,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4154,7 +4154,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4188,7 +4188,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4222,7 +4222,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4256,7 +4256,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4290,7 +4290,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-14">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4324,7 +4324,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4358,7 +4358,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4392,7 +4392,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4426,7 +4426,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4460,7 +4460,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4494,7 +4494,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4528,7 +4528,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4562,7 +4562,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4596,7 +4596,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4630,7 +4630,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4664,7 +4664,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4698,7 +4698,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4732,7 +4732,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4766,7 +4766,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4800,7 +4800,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4834,7 +4834,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4868,7 +4868,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4902,7 +4902,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4936,7 +4936,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4970,7 +4970,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5004,7 +5004,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5038,7 +5038,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5072,7 +5072,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5106,7 +5106,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-14">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5140,7 +5140,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5174,7 +5174,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5208,7 +5208,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5242,7 +5242,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5276,7 +5276,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-08">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5310,7 +5310,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5344,7 +5344,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5378,7 +5378,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5412,7 +5412,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5446,7 +5446,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5480,7 +5480,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5514,7 +5514,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5548,7 +5548,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-03-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-03-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5582,7 +5582,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-03-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-03-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5616,7 +5616,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2000-01-01">
+       <a class="action-link quiz-link" href="quiz?date=2000-01-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>

--- a/instructions.html
+++ b/instructions.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/instructions.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/instructions">
     <title>New Features! - Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
@@ -35,13 +35,13 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Puzzles</a>
+        <a href="./" class="back-link">← Back to All Puzzles</a>
 
         <div class="instructions-container">
             <div class="whats-new-section">
                 <h2>⚾ New for 2026 Season</h2>
                 <ul>
-                    <li><strong>Interactive Analytics:</strong> Click on any chart on the <a href="analytics.html">Analytics Page</a> to instantly filter the archive by team, decade, or "Toughest Puzzles."</li>
+                    <li><strong>Interactive Analytics:</strong> Click on any chart on the <a href="analytics">Analytics Page</a> to instantly filter the archive by team, decade, or "Toughest Puzzles."</li>
                     <li><strong>Persistent Score Breakdown:</strong> Click the "Score Pill" in the header to see a detailed breakdown of your performance across all hint levels.</li>
                     <li><strong>Wordle-style Sharing:</strong> Sharing your score now generates a colorful emoji grid (e.g., 📘 🟩) showing your path to victory. On mobile, use your phone's native share feature to send results instantly.</li>
                     <li><strong>Deep-Dive Trivia:</strong> After revealing a player, use the new interactive "Follow-up Questions" on player detail pages to learn even more high-interest facts about their career.</li>

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -229,7 +229,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
     <link rel="canonical" href="https://namethatyankeequiz.com/{date_str}">
     
     <!-- Meta tags for better social sharing -->
-    <meta name="description" content="The player revealed for this New York Yankees trivia puzzle is {name}.">
+    <meta name="description" content="Discover the career highlights and statistics for {name}, the featured New York Yankee for the {formatted_date} trivia puzzle.">
     <meta property="og:title" content="Name That Yankee - {formatted_date}">
     <meta property="og:description" content="Can you name this New York Yankee based on their career stats?">
     <meta property="og:type" content="website">
@@ -248,7 +248,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
       "@context": "https://schema.org",
       "@type": "Article",
       "headline": "Name That Yankee Answer for {formatted_date}",
-      "description": {json.dumps(f"The player revealed for this New York Yankees trivia puzzle is {name}.")},
+      "description": {json.dumps(f"Discover the career highlights and statistics for {name}, the featured New York Yankee for the {formatted_date} trivia puzzle.")},
       "image": "https://namethatyankeequiz.com/images/clue-{date_str}.webp",
       "author": {{
         "@type": "Person",

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -272,7 +272,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
             <h1>The answer for {formatted_date} is...</h1>
         </div>
         <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
+            <a href="instructions" class="instructions-link">New Features!</a>
             <div id="score-display">
                 Your Score: <span id="total-score">0</span>
                 <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -294,7 +294,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
+        <a href="./" class="back-link">← Back to All Questions</a>
 
         <div class="detail-layout">
             <div class="left-column">
@@ -451,7 +451,7 @@ def rebuild_index_page(project_dir: Path):
                             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
                             <span>Reveal</span>
                         </a>
-                        <a href="quiz.html?date={date_str}" class="action-link quiz-link">
+                        <a href="quiz?date={date_str}" class="action-link quiz-link">
                             <svg xmlns="http://www.w3.org/2000/svg" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/><path d="M12 17h.01"/></svg>
                             <span>Quiz</span>
                         </a>

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -2,61 +2,123 @@ import re
 import os
 import glob
 import argparse
+from bs4 import BeautifulSoup
 
-def extract_metadata(html_content):
-    # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
-    # Added re.DOTALL and flexible whitespace to handle multiline <title> tags
-    match = re.search(r'<title>\s*(.*?)\s*Answer - \s*(.*?)\s*\| Name That Yankee\s*</title>', html_content, re.DOTALL)
-    if match:
-        player_name = match.group(1).strip()
-        date = match.group(2).strip()
-        # Handle cases where there might be newlines inside the captured groups
-        player_name = " ".join(player_name.split())
-        date = " ".join(date.split())
-        return player_name, date
-    return None, None
+def extract_metadata(soup, date_stem=None):
+    """
+    Extract player name and date from the BeautifulSoup object.
+    Try to use date_stem if provided, otherwise extract from title.
+    Player name: Try <title>, then <h2> in .header-content.
+    """
+    date = date_stem
+    title_tag = soup.title
+    title_text = title_tag.get_text() if title_tag else ""
+    
+    # If date not provided, try to extract from title
+    if not date and title_text:
+        # Match "Babe Ruth Answer - 2025-03-29 | Name That Yankee"
+        match = re.search(r'Answer - \s*(\d{4}-\d{2}-\d{2})', title_text)
+        if match:
+            date = match.group(1).strip()
+        else:
+            # Match "Answer for 2026-03-05 | Name That Yankee"
+            match = re.search(r'Answer for (\d{4}-\d{2}-\d{2})', title_text)
+            if match:
+                date = match.group(1).strip()
 
-def scrub_and_inject(html_content, player_name, date):
-    # Remove existing description and canonical tags
-    html_content = re.sub(r'\s*<meta name="description" content=".*?">', '', html_content)
-    html_content = re.sub(r'\s*<link rel="canonical" href=".*?">', '', html_content)
-    
-    # Standardized tags
-    canonical_tag = f'\n    <link rel="canonical" href="https://namethatyankeequiz.com/{date}">'
-    description_tag = f'\n    <meta name="description" content="Discover the career highlights and statistics for {player_name}, the featured New York Yankee for the {date} trivia puzzle.">'
-    
-    # Inject after viewport tag
-    viewport_pattern = r'(<meta name="viewport" content=".*?">)'
-    if re.search(viewport_pattern, html_content):
-        html_content = re.sub(viewport_pattern, r'\1' + canonical_tag + description_tag, html_content)
+    player_name = None
+    if title_text:
+        # Try to extract name from title: "[Player Name] Answer - [Date] | Name That Yankee"
+        match = re.search(r'(.*?)\s*Answer -', title_text, re.DOTALL)
+        if match:
+            player_name = match.group(1).strip()
+            # Clean up multiline/extra spaces
+            player_name = " ".join(player_name.split())
+
+    if not player_name or player_name.lower() == "answer for":
+        # Try <h2> in .header-content
+        header_content = soup.find(class_='header-content')
+        if header_content:
+            h2 = header_content.find('h2')
+            if h2:
+                player_name = h2.get_text(strip=True)
         
-    return html_content
+        # Fallback to any <h2> if not found in .header-content
+        if not player_name:
+            h2 = soup.find('h2')
+            if h2:
+                player_name = h2.get_text(strip=True)
 
-def normalize_links(html_content):
-    # Replace href="YYYY-MM-DD.html" with href="YYYY-MM-DD"
-    # Matches href="2025-03-29.html" -> href="2025-03-29"
-    pattern = r'href="(\d{4}-\d{2}-\d{2})\.html"'
-    return re.sub(pattern, r'href="\1"', html_content)
+    return player_name, date
+
+def scrub_and_inject(soup, player_name, date):
+    """
+    Remove existing description and canonical tags and inject new ones.
+    """
+    # Remove existing description and canonical tags
+    for tag in soup.find_all('meta', attrs={'name': 'description'}):
+        tag.decompose()
+    for tag in soup.find_all('link', attrs={'rel': 'canonical'}):
+        tag.decompose()
+    
+    # Create new tags
+    new_canonical = soup.new_tag('link', rel='canonical', href=f'https://namethatyankeequiz.com/{date}')
+    description_content = f'Discover the career highlights and statistics for {player_name}, the featured New York Yankee for the {date} trivia puzzle.'
+    new_description = soup.new_tag('meta', attrs={'name': 'description', 'content': description_content})
+    
+    # Inject into head
+    if soup.head:
+        # Find viewport tag to inject after it
+        viewport = soup.head.find('meta', attrs={'name': 'viewport'})
+        if viewport:
+            viewport.insert_after(new_canonical)
+            new_canonical.insert_after(new_description)
+        else:
+            # Fallback to appending to head
+            soup.head.append(new_canonical)
+            soup.head.append(new_description)
+            
+    return soup
+
+def normalize_links(soup):
+    """
+    Normalize internal <a> links to be extensionless.
+    """
+    for a in soup.find_all('a', href=True):
+        href = a['href']
+        # Replace .html with extensionless for internal links
+        # We only target files that look like internal pages (date format or index.html)
+        if href.endswith('.html'):
+            # Only replace if it doesn't look like an external link (though those usually don't end in .html)
+            if not href.startswith(('http://', 'https://')):
+                a['href'] = href.replace('.html', '')
+    return soup
 
 def process_file(file_path, dry_run=True):
     with open(file_path, 'r', encoding='utf-8') as f:
         content = f.read()
     
-    player_name, date = extract_metadata(content)
+    soup = BeautifulSoup(content, 'html.parser')
+    date_stem = os.path.basename(file_path).replace('.html', '')
+    
+    player_name, date = extract_metadata(soup, date_stem)
     if not player_name or not date:
         print(f"Skipping {file_path}: Metadata not found")
         return
     
-    new_content = scrub_and_inject(content, player_name, date)
-    new_content = normalize_links(new_content)
+    soup = scrub_and_inject(soup, player_name, date)
+    soup = normalize_links(soup)
+    
+    # Use str(soup) for the new content. BeautifulSoup might reformat slightly.
+    new_content = str(soup)
     
     if content != new_content:
         if dry_run:
-            print(f"[DRY RUN] Would update {file_path}")
+            print(f"[DRY RUN] Would update {file_path} (Player: {player_name}, Date: {date})")
         else:
             with open(file_path, 'w', encoding='utf-8') as f:
                 f.write(new_content)
-            print(f"Updated {file_path}")
+            print(f"Updated {file_path} (Player: {player_name}, Date: {date})")
 
 def main():
     parser = argparse.ArgumentParser(description="SEO Cleanup Utility")

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -1,0 +1,10 @@
+import re
+
+def extract_metadata(html_content):
+    # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
+    match = re.search(r'<title>(.*?) Answer - (.*?) \| Name That Yankee</title>', html_content)
+    if match:
+        player_name = match.group(1).strip()
+        date = match.group(2).strip()
+        return player_name, date
+    return None, None

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -24,3 +24,9 @@ def scrub_and_inject(html_content, player_name, date):
         html_content = re.sub(viewport_pattern, r'\1' + canonical_tag + description_tag, html_content)
         
     return html_content
+
+def normalize_links(html_content):
+    # Replace href="YYYY-MM-DD.html" with href="YYYY-MM-DD"
+    # Matches href="2025-03-29.html" -> href="2025-03-29"
+    pattern = r'href="(\d{4}-\d{2}-\d{2})\.html"'
+    return re.sub(pattern, r'href="\1"', html_content)

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -5,10 +5,14 @@ import argparse
 
 def extract_metadata(html_content):
     # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
-    match = re.search(r'<title>(.*?) Answer - (.*?) \| Name That Yankee</title>', html_content)
+    # Added re.DOTALL and flexible whitespace to handle multiline <title> tags
+    match = re.search(r'<title>\s*(.*?)\s*Answer - \s*(.*?)\s*\| Name That Yankee\s*</title>', html_content, re.DOTALL)
     if match:
         player_name = match.group(1).strip()
         date = match.group(2).strip()
+        # Handle cases where there might be newlines inside the captured groups
+        player_name = " ".join(player_name.split())
+        date = " ".join(date.split())
         return player_name, date
     return None, None
 

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -8,3 +8,19 @@ def extract_metadata(html_content):
         date = match.group(2).strip()
         return player_name, date
     return None, None
+
+def scrub_and_inject(html_content, player_name, date):
+    # Remove existing description and canonical tags
+    html_content = re.sub(r'\s*<meta name="description" content=".*?">', '', html_content)
+    html_content = re.sub(r'\s*<link rel="canonical" href=".*?">', '', html_content)
+    
+    # Standardized tags
+    canonical_tag = f'\n    <link rel="canonical" href="https://namethatyankeequiz.com/{date}">'
+    description_tag = f'\n    <meta name="description" content="Discover the career highlights and statistics for {player_name}, the featured New York Yankee for the {date} trivia puzzle.">'
+    
+    # Inject after viewport tag
+    viewport_pattern = r'(<meta name="viewport" content=".*?">)'
+    if re.search(viewport_pattern, html_content):
+        html_content = re.sub(viewport_pattern, r'\1' + canonical_tag + description_tag, html_content)
+        
+    return html_content

--- a/page-generator/seo_cleanup.py
+++ b/page-generator/seo_cleanup.py
@@ -1,4 +1,7 @@
 import re
+import os
+import glob
+import argparse
 
 def extract_metadata(html_content):
     # Regex to find <title> tag content: [Player Name] Answer - [Date] | Name That Yankee
@@ -30,3 +33,37 @@ def normalize_links(html_content):
     # Matches href="2025-03-29.html" -> href="2025-03-29"
     pattern = r'href="(\d{4}-\d{2}-\d{2})\.html"'
     return re.sub(pattern, r'href="\1"', html_content)
+
+def process_file(file_path, dry_run=True):
+    with open(file_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    
+    player_name, date = extract_metadata(content)
+    if not player_name or not date:
+        print(f"Skipping {file_path}: Metadata not found")
+        return
+    
+    new_content = scrub_and_inject(content, player_name, date)
+    new_content = normalize_links(new_content)
+    
+    if content != new_content:
+        if dry_run:
+            print(f"[DRY RUN] Would update {file_path}")
+        else:
+            with open(file_path, 'w', encoding='utf-8') as f:
+                f.write(new_content)
+            print(f"Updated {file_path}")
+
+def main():
+    parser = argparse.ArgumentParser(description="SEO Cleanup Utility")
+    parser.add_argument("--no-dry-run", action="store_false", dest="dry_run", help="Apply changes")
+    parser.set_defaults(dry_run=True)
+    args = parser.parse_args()
+    
+    # Find YYYY-MM-DD.html files in the current root
+    html_files = glob.glob("????-??-??.html")
+    for file_path in html_files:
+        process_file(file_path, args.dry_run)
+
+if __name__ == "__main__":
+    main()

--- a/quiz.html
+++ b/quiz.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/quiz.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/quiz">
     <title>Name That Yankee - Quiz</title>
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
@@ -31,9 +31,9 @@
             const canonical = document.createElement('link');
             canonical.rel = 'canonical';
             if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-                canonical.href = 'https://namethatyankeequiz.com/quiz.html?date=' + date;
+                canonical.href = 'https://namethatyankeequiz.com/quiz?date=' + date;
             } else {
-                canonical.href = 'https://namethatyankeequiz.com/quiz.html';
+                canonical.href = 'https://namethatyankeequiz.com/quiz';
             }
             document.head.appendChild(canonical);
         })();
@@ -46,7 +46,7 @@
             <h1 id="quiz-title">Name That Yankee Quiz</h1>
         </div>
         <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
+            <a href="instructions" class="instructions-link">New Features!</a>
             <div id="score-display">
                 Your Score: <span id="total-score">0</span>
                 <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -68,7 +68,7 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
+        <a href="./" class="back-link">← Back to All Questions</a>
 
         <div class="quiz-layout">
             <div class="left-column">

--- a/tests/fixtures/www/analytics.html
+++ b/tests/fixtures/www/analytics.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/analytics.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/analytics">
     <title>Site Analytics - Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="icon" type="image/x-icon" href="images/favicon.ico">
@@ -16,7 +16,7 @@
             <h1>Site Analytics</h1>
         </div>
         <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
+            <a href="instructions" class="instructions-link">New Features!</a>
             <div id="score-display">
                 Your Score: <span id="total-score">0</span>
                 <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -38,7 +38,7 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Puzzles</a>
+        <a href="./" class="back-link">← Back to All Puzzles</a>
 
         <div id="loading-message" class="text-center p-8">
             <p class="text-xl font-semibold">Loading analytics data...</p>

--- a/tests/fixtures/www/index.html
+++ b/tests/fixtures/www/index.html
@@ -88,6 +88,74 @@
   </div>
   <main>
    <div class="gallery" id="gallery-grid">
+    <div class="gallery-container" data-search-terms="april 14 2026 min cal bos bal oak nyy 1976 1979 1970 1974 1975 1986 1981 1985 1973 1978 1971 1972 1984 1980 1988 1987 1982 1977 1983 minnesota twins california angels boston red sox baltimore orioles oakland athletics new york yankees">
+     <a class="gallery-item" href="2026-04-14">
+      <img alt="Name that Yankee trivia card from 2026-04-14" src="images/clue-2026-04-14.webp"/>
+     </a>
+     <div class="p-4">
+      <p class="gallery-date">
+       Trivia Date: April 14, 2026
+      </p>
+      <div class="action-links">
+       <a class="action-link reveal-link" href="2026-04-14">
+        <svg fill="none" height="20" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+         <circle cx="11" cy="11" r="8">
+         </circle>
+         <path d="m21 21-4.3-4.3">
+         </path>
+        </svg>
+        <span>
+         Reveal
+        </span>
+       </a>
+       <a class="action-link quiz-link" href="quiz.html?date=2026-04-14">
+        <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
+         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
+         </path>
+         <path d="M12 17h.01">
+         </path>
+        </svg>
+        <span>
+         Quiz
+        </span>
+       </a>
+      </div>
+     </div>
+    </div>
+    <div class="gallery-container" data-search-terms="april 13 2026 nyy kca cal oak bal 1974 1984 1971 1981 1967 1978 1979 1972 1987 1982 1970 1968 1977 1973 1986 1976 1985 1983 1980 1975 1969 new york yankees california angels oakland athletics baltimore orioles">
+     <a class="gallery-item" href="2026-04-13">
+      <img alt="Name that Yankee trivia card from 2026-04-13" src="images/clue-2026-04-13.webp"/>
+     </a>
+     <div class="p-4">
+      <p class="gallery-date">
+       Trivia Date: April 13, 2026
+      </p>
+      <div class="action-links">
+       <a class="action-link reveal-link" href="2026-04-13">
+        <svg fill="none" height="20" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
+         <circle cx="11" cy="11" r="8">
+         </circle>
+         <path d="m21 21-4.3-4.3">
+         </path>
+        </svg>
+        <span>
+         Reveal
+        </span>
+       </a>
+       <a class="action-link quiz-link" href="quiz.html?date=2026-04-13">
+        <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
+         <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
+         </path>
+         <path d="M12 17h.01">
+         </path>
+        </svg>
+        <span>
+         Quiz
+        </span>
+       </a>
+      </div>
+     </div>
+    </div>
     <div class="gallery-container" data-search-terms="april 12 2026 cle nyy tbr 2010 2011 2013 2007 2012 2008 2009 cleveland indians guardians new york yankees tampa bay rays devil">
      <a class="gallery-item" href="2026-04-12">
       <img alt="Name that Yankee trivia card from 2026-04-12" src="images/clue-2026-04-12.webp"/>
@@ -5529,7 +5597,7 @@
      </div>
     </div>
     <div class="gallery-container" data-search-terms="january 01 2000">
-     <a class="gallery-item" href="2000-01-01.html">
+     <a class="gallery-item" href="2000-01-01">
       <img alt="Name that Yankee trivia card from 2000-01-01" src="images/clue-2000-01-01.webp"/>
      </a>
      <div class="p-4">
@@ -5537,7 +5605,7 @@
        Trivia Date: January 01, 2000
       </p>
       <div class="action-links">
-       <a class="action-link reveal-link" href="2000-01-01.html">
+       <a class="action-link reveal-link" href="2000-01-01">
         <svg fill="none" height="20" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="20" xmlns="http://www.w3.org/2000/svg">
          <circle cx="11" cy="11" r="8">
          </circle>
@@ -5574,7 +5642,7 @@
     This site is an unofficial fan project and is not affiliated with the New York Yankees, Major League Baseball, or the YES Network. All trademarks and copyrights belong to their respective owners.
    </p>
    <p id="last-updated">
-    Last Updated: 12-Apr-2026
+    Last Updated: 15-Apr-2026
    </p>
    <p class="copyright">
     <a href="https://namethatyankeequiz.com">

--- a/tests/fixtures/www/index.html
+++ b/tests/fixtures/www/index.html
@@ -34,10 +34,10 @@
     </p>
    </div>
    <div class="header-controls">
-    <a class="instructions-link" href="instructions.html">
+    <a class="instructions-link" href="instructions">
      New Features!
     </a>
-    <a class="analytics-link" href="analytics.html">
+    <a class="analytics-link" href="analytics">
      📊 Site Analytics
     </a>
     <div id="score-display">
@@ -108,7 +108,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-14">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -142,7 +142,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-13">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -176,7 +176,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-12">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -210,7 +210,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-10">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -244,7 +244,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-09">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -278,7 +278,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-08">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -312,7 +312,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-07">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -346,7 +346,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-05">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -380,7 +380,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-04">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -414,7 +414,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-03">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -448,7 +448,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-04-01">
+       <a class="action-link quiz-link" href="quiz?date=2026-04-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -482,7 +482,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-31">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -516,7 +516,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-30">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -550,7 +550,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-27">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -584,7 +584,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-22">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -618,7 +618,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-19">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -652,7 +652,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-18">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -686,7 +686,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-15">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -720,7 +720,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-11">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -754,7 +754,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-06">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -788,7 +788,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-03-05">
+       <a class="action-link quiz-link" href="quiz?date=2026-03-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -822,7 +822,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2026-02-28">
+       <a class="action-link quiz-link" href="quiz?date=2026-02-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -856,7 +856,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -890,7 +890,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -924,7 +924,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -958,7 +958,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -992,7 +992,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1026,7 +1026,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1060,7 +1060,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1094,7 +1094,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1128,7 +1128,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1162,7 +1162,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1196,7 +1196,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1230,7 +1230,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1264,7 +1264,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1298,7 +1298,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1332,7 +1332,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1366,7 +1366,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1400,7 +1400,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1434,7 +1434,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1468,7 +1468,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1502,7 +1502,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1536,7 +1536,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-09-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-09-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1570,7 +1570,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-31">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1604,7 +1604,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1638,7 +1638,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1672,7 +1672,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1706,7 +1706,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1740,7 +1740,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1774,7 +1774,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1808,7 +1808,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1842,7 +1842,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1876,7 +1876,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1910,7 +1910,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1944,7 +1944,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -1978,7 +1978,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2012,7 +2012,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2046,7 +2046,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2080,7 +2080,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2114,7 +2114,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2148,7 +2148,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2182,7 +2182,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2216,7 +2216,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2250,7 +2250,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2284,7 +2284,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2318,7 +2318,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2352,7 +2352,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-08-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-08-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2386,7 +2386,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-31">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-31">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2420,7 +2420,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2454,7 +2454,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2488,7 +2488,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2522,7 +2522,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2556,7 +2556,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2590,7 +2590,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2624,7 +2624,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2658,7 +2658,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2692,7 +2692,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2726,7 +2726,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2760,7 +2760,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2794,7 +2794,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2828,7 +2828,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2862,7 +2862,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2896,7 +2896,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2930,7 +2930,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2964,7 +2964,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-08">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -2998,7 +2998,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3032,7 +3032,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3066,7 +3066,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3100,7 +3100,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3134,7 +3134,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3168,7 +3168,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-07-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-07-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3202,7 +3202,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3236,7 +3236,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3270,7 +3270,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3304,7 +3304,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3338,7 +3338,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3372,7 +3372,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3406,7 +3406,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3440,7 +3440,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3474,7 +3474,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3508,7 +3508,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3542,7 +3542,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3576,7 +3576,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3610,7 +3610,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3644,7 +3644,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3678,7 +3678,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3712,7 +3712,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3746,7 +3746,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3780,7 +3780,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3814,7 +3814,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3848,7 +3848,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3882,7 +3882,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3916,7 +3916,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-06-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-06-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3950,7 +3950,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -3984,7 +3984,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4018,7 +4018,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-26">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-26">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4052,7 +4052,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4086,7 +4086,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-24">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-24">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4120,7 +4120,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4154,7 +4154,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4188,7 +4188,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4222,7 +4222,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4256,7 +4256,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-16">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-16">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4290,7 +4290,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-14">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4324,7 +4324,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4358,7 +4358,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4392,7 +4392,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4426,7 +4426,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-10">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-10">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4460,7 +4460,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4494,7 +4494,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4528,7 +4528,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4562,7 +4562,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4596,7 +4596,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4630,7 +4630,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-05-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-05-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4664,7 +4664,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4698,7 +4698,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4732,7 +4732,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-28">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-28">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4766,7 +4766,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-27">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-27">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4800,7 +4800,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-25">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-25">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4834,7 +4834,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-23">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-23">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4868,7 +4868,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-22">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-22">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4902,7 +4902,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-21">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-21">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4936,7 +4936,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-20">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-20">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -4970,7 +4970,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-19">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-19">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5004,7 +5004,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-18">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-18">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5038,7 +5038,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-17">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-17">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5072,7 +5072,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-15">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-15">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5106,7 +5106,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-14">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-14">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5140,7 +5140,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-13">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-13">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5174,7 +5174,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-12">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-12">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5208,7 +5208,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-11">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-11">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5242,7 +5242,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-09">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-09">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5276,7 +5276,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-08">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-08">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5310,7 +5310,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-07">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-07">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5344,7 +5344,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-06">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-06">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5378,7 +5378,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-05">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-05">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5412,7 +5412,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-04">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-04">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5446,7 +5446,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-03">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-03">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5480,7 +5480,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-02">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-02">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5514,7 +5514,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-04-01">
+       <a class="action-link quiz-link" href="quiz?date=2025-04-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5548,7 +5548,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-03-30">
+       <a class="action-link quiz-link" href="quiz?date=2025-03-30">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5582,7 +5582,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2025-03-29">
+       <a class="action-link quiz-link" href="quiz?date=2025-03-29">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>
@@ -5616,7 +5616,7 @@
          Reveal
         </span>
        </a>
-       <a class="action-link quiz-link" href="quiz.html?date=2000-01-01">
+       <a class="action-link quiz-link" href="quiz?date=2000-01-01">
         <svg fill="none" height="28" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="28" xmlns="http://www.w3.org/2000/svg">
          <path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3">
          </path>

--- a/tests/fixtures/www/instructions.html
+++ b/tests/fixtures/www/instructions.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/instructions.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/instructions">
     <title>New Features! - Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="shortcut icon" type="image/x-icon" href="favicon.ico">
@@ -35,13 +35,13 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Puzzles</a>
+        <a href="./" class="back-link">← Back to All Puzzles</a>
 
         <div class="instructions-container">
             <div class="whats-new-section">
                 <h2>⚾ New for 2026 Season</h2>
                 <ul>
-                    <li><strong>Interactive Analytics:</strong> Click on any chart on the <a href="analytics.html">Analytics Page</a> to instantly filter the archive by team, decade, or "Toughest Puzzles."</li>
+                    <li><strong>Interactive Analytics:</strong> Click on any chart on the <a href="analytics">Analytics Page</a> to instantly filter the archive by team, decade, or "Toughest Puzzles."</li>
                     <li><strong>Persistent Score Breakdown:</strong> Click the "Score Pill" in the header to see a detailed breakdown of your performance across all hint levels.</li>
                     <li><strong>Wordle-style Sharing:</strong> Sharing your score now generates a colorful emoji grid (e.g., 📘 🟩) showing your path to victory. On mobile, use your phone's native share feature to send results instantly.</li>
                     <li><strong>Deep-Dive Trivia:</strong> After revealing a player, use the new interactive "Follow-up Questions" on player detail pages to learn even more high-interest facts about their career.</li>

--- a/tests/fixtures/www/quiz.html
+++ b/tests/fixtures/www/quiz.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="canonical" href="https://namethatyankeequiz.com/quiz.html">
+    <link rel="canonical" href="https://namethatyankeequiz.com/quiz">
     <title>Name That Yankee - Quiz</title>
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
@@ -31,9 +31,9 @@
             const canonical = document.createElement('link');
             canonical.rel = 'canonical';
             if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
-                canonical.href = 'https://namethatyankeequiz.com/quiz.html?date=' + date;
+                canonical.href = 'https://namethatyankeequiz.com/quiz?date=' + date;
             } else {
-                canonical.href = 'https://namethatyankeequiz.com/quiz.html';
+                canonical.href = 'https://namethatyankeequiz.com/quiz';
             }
             document.head.appendChild(canonical);
         })();
@@ -46,7 +46,7 @@
             <h1 id="quiz-title">Name That Yankee Quiz</h1>
         </div>
         <div class="header-controls">
-            <a href="instructions.html" class="instructions-link">New Features!</a>
+            <a href="instructions" class="instructions-link">New Features!</a>
             <div id="score-display">
                 Your Score: <span id="total-score">0</span>
                 <svg aria-hidden="true" class="chevron-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
@@ -68,7 +68,7 @@
     </header>
 
     <main>
-        <a href="index.html" class="back-link">← Back to All Questions</a>
+        <a href="./" class="back-link">← Back to All Questions</a>
 
         <div class="quiz-layout">
             <div class="left-column">

--- a/tests/test_seo_cleanup.py
+++ b/tests/test_seo_cleanup.py
@@ -1,0 +1,31 @@
+import pytest
+import sys
+import os
+
+# Add the project root to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+# Add page-generator to sys.path to allow importing from it directly
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'page-generator')))
+
+from seo_cleanup import extract_metadata, scrub_and_inject, normalize_links
+
+def test_extract_metadata():
+    html = "<title>Babe Ruth Answer - 2025-03-29 | Name That Yankee</title>"
+    name, date = extract_metadata(html)
+    assert name == "Babe Ruth"
+    assert date == "2025-03-29"
+
+def test_scrub_and_inject():
+    html = '<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<meta name="description" content="old">\n<link rel="canonical" href="old">'
+    name = "Babe Ruth"
+    date = "2025-03-29"
+    result = scrub_and_inject(html, name, date)
+    assert 'https://namethatyankeequiz.com/2025-03-29' in result
+    assert 'career highlights and statistics for Babe Ruth' in result
+    assert 'content="old"' not in result
+    assert 'href="old"' not in result
+
+def test_normalize_links():
+    html = '<a href="2025-03-30.html">Next</a>'
+    result = normalize_links(html)
+    assert result == '<a href="2025-03-30">Next</a>'

--- a/tests/test_seo_cleanup.py
+++ b/tests/test_seo_cleanup.py
@@ -1,6 +1,7 @@
 import pytest
 import sys
 import os
+from bs4 import BeautifulSoup
 
 # Add the project root to sys.path
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
@@ -9,23 +10,60 @@ sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'p
 
 from seo_cleanup import extract_metadata, scrub_and_inject, normalize_links
 
-def test_extract_metadata():
+def test_extract_metadata_standard():
     html = "<title>Babe Ruth Answer - 2025-03-29 | Name That Yankee</title>"
-    name, date = extract_metadata(html)
+    soup = BeautifulSoup(html, 'html.parser')
+    name, date = extract_metadata(soup)
     assert name == "Babe Ruth"
     assert date == "2025-03-29"
 
-def test_scrub_and_inject():
-    html = '<meta name="viewport" content="width=device-width, initial-scale=1.0">\n<meta name="description" content="old">\n<link rel="canonical" href="old">'
-    name = "Babe Ruth"
-    date = "2025-03-29"
-    result = scrub_and_inject(html, name, date)
-    assert 'https://namethatyankeequiz.com/2025-03-29' in result
-    assert 'career highlights and statistics for Babe Ruth' in result
-    assert 'content="old"' not in result
-    assert 'href="old"' not in result
+def test_extract_metadata_2026_format():
+    html = "<title>Answer for 2026-03-05 | Name That Yankee</title><h2>Derek Jeter</h2>"
+    soup = BeautifulSoup(html, 'html.parser')
+    name, date = extract_metadata(soup)
+    assert name == "Derek Jeter"
+    assert date == "2026-03-05"
 
-def test_normalize_links():
-    html = '<a href="2025-03-30.html">Next</a>'
-    result = normalize_links(html)
-    assert result == '<a href="2025-03-30">Next</a>'
+def test_extract_metadata_multiline_and_extra_space():
+    html = """
+    <title>
+        Lou Gehrig 
+        Answer - 
+        2025-04-01 | 
+        Name That Yankee
+    </title>
+    """
+    soup = BeautifulSoup(html, 'html.parser')
+    name, date = extract_metadata(soup)
+    assert name == "Lou Gehrig"
+    assert date == "2025-04-01"
+
+def test_scrub_and_inject_robust():
+    html = """
+    <html>
+    <head>
+        <meta content="width=device-width, initial-scale=1.0" name="viewport">
+        <link href="old" rel="canonical">
+        <meta content="old" name="description">
+    </head>
+    <body></body>
+    </html>
+    """
+    name = "Babe Ruth"
+    date_stem = "2025-03-29"
+    soup = BeautifulSoup(html, 'html.parser')
+    result_soup = scrub_and_inject(soup, name, date_stem)
+    result_html = str(result_soup)
+    
+    assert 'href="https://namethatyankeequiz.com/2025-03-29"' in result_html
+    assert 'career highlights and statistics for Babe Ruth' in result_html
+    assert 'content="old"' not in result_html
+    assert 'href="old"' not in result_html
+
+def test_normalize_links_bs4():
+    html = '<div><a href="2025-03-30.html">Next</a><a href="index.html">Home</a></div>'
+    soup = BeautifulSoup(html, 'html.parser')
+    result_soup = normalize_links(soup)
+    result_html = str(result_soup)
+    assert 'href="2025-03-30"' in result_html
+    assert 'href="index"' in result_html

--- a/tests/unit/page_generator/test_seo_metadata.py
+++ b/tests/unit/page_generator/test_seo_metadata.py
@@ -44,7 +44,7 @@ def test_meta_description_in_detail_page(sample_player_data):
     
     meta_desc = soup.find("meta", attrs={"name": "description"})
     assert meta_desc is not None
-    assert meta_desc["content"] == "The player revealed for this New York Yankees trivia puzzle is Derek Jeter."
+    assert meta_desc["content"] == f"Discover the career highlights and statistics for Derek Jeter, the featured New York Yankee for the {formatted_date} trivia puzzle."
 
 def test_json_ld_in_detail_page(sample_player_data):
     date_str = "1999-05-15"
@@ -77,7 +77,7 @@ def test_json_ld_with_quoted_name(sample_player_data):
     
     # This should be valid JSON
     data = json.loads(script_tag.string)
-    assert data["description"] == 'The player revealed for this New York Yankees trivia puzzle is Babe "The Bambino" Ruth.'
+    assert data["description"] == f'Discover the career highlights and statistics for Babe "The Bambino" Ruth, the featured New York Yankee for the {formatted_date} trivia puzzle.'
 
 def test_robots_txt_existence():
     # Resolving path relative to the test file for robustness across environments


### PR DESCRIPTION
## Summary
- Standardized SEO metadata across all 160+ historical trivia pages using a new BeautifulSoup-based cleanup utility.
- Updated the automation pipeline (`html_generator.py`) to generate unique meta descriptions and clean canonical URLs for all future pages.
- Normalized all site-wide internal links in `index.html`, `quiz.html`, `instructions.html`, and `analytics.html` to be extensionless.
- Fixed a minor link consistency issue in `js/quiz.js`.

## Test Plan
- [x] Run full test suite (`./run_tests.sh`) - 288 tests passing.
- [x] Manual spot check of historical pages for metadata accuracy.
- [x] Verify extensionless navigation across the site.