### PR TITLE
fix: seo remediation for indexing errors

### DIFF
--- a/docs/superpowers/plans/2026-04-23-seo-remediation.md
+++ b/docs/superpowers/plans/2026-04-23-seo-remediation.md
@@ -1,0 +1,154 @@
+# SEO Remediation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resolve Google Search Console indexing errors by adding a static noindex tag to quiz pages, normalizing internal links to the root domain (`/`), and generating rich, descriptive titles for historical puzzle pages.
+
+**Architecture:** 
+1. `quiz.html` will have a static `<meta name="robots" content="noindex">` added to its `<head>`, and its canonical tag script will be simplified.
+2. `manifest.json`, `js/analytics.js`, and `js/quiz.js` will be updated to point to `/` instead of `index.html`.
+3. `page-generator/html_generator.py` will be updated to generate a richer `<title>` tag for the detail pages.
+
+**Tech Stack:** HTML, JavaScript, Python
+
+---
+
+### Task 1: Add static noindex to quiz.html
+
+**Files:**
+- Modify: `quiz.html:20-40`
+
+- [ ] **Step 1: Replace JS-based canonical/noindex with static tags**
+
+```html
+    <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+    
+    <!-- Do not index interactive quiz states -->
+    <meta name="robots" content="noindex">
+    
+    <script>
+        (function() {
+            const params = new URLSearchParams(window.location.search);
+            const date = params.get('date');
+            const canonical = document.createElement('link');
+            canonical.rel = 'canonical';
+            if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
+                // Point canonical to the Reveal page
+                canonical.href = 'https://namethatyankeequiz.com/' + date;
+            } else {
+                canonical.href = 'https://namethatyankeequiz.com/quiz';
+            }
+            document.head.appendChild(canonical);
+        })();
+    </script>
+</head>
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add quiz.html
+git commit -m "seo: add static noindex to quiz.html"
+```
+
+---
+
+### Task 2: Normalize internal links to the root domain
+
+**Files:**
+- Modify: `manifest.json:4-6`
+- Modify: `js/analytics.js:93-95`
+- Modify: `js/analytics.js:130-132`
+- Modify: `js/quiz.js:26-28`
+
+- [ ] **Step 1: Update manifest.json**
+
+```json
+  "description": "Can you name this New York Yankee based on their career stats?",
+  "start_url": "/",
+  "display": "standalone",
+```
+
+- [ ] **Step 2: Update js/analytics.js (Team Filter)**
+
+```javascript
+            onClick: (event, elements) => {
+                if (elements.length > 0) {
+                    const clickedIndex = elements[0].index;
+                    const teamAbbreviation = labels[clickedIndex];
+                    window.location.href = `/?search=${teamAbbreviation}`;
+                }
+            }
+```
+
+- [ ] **Step 3: Update js/analytics.js (Decade Filter)**
+
+```javascript
+            onClick: (event, elements) => {
+                if (elements.length > 0) {
+                    const clickedIndex = elements[0].index;
+                    const decade = originalDecades[clickedIndex]; // e.g., 1980
+                    window.location.href = `/?decade=${decade}`;
+                }
+            }
+```
+
+- [ ] **Step 4: Update js/quiz.js**
+
+```javascript
+    if (params.get('reset') === 'true') {
+        localStorage.removeItem('nameThatYankeeTotalScore');
+        localStorage.removeItem('nameThatYankeeCompletedPuzzles');
+        localStorage.removeItem('nameThatYankeeScoreBreakdown');
+        alert('Your score and quiz history have been reset.');
+        window.location.assign('/');
+        return;
+    }
+```
+
+- [ ] **Step 5: Run frontend tests to ensure no regressions**
+
+```bash
+npm run test
+```
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add manifest.json js/analytics.js js/quiz.js
+git commit -m "seo: normalize internal links to root domain"
+```
+
+---
+
+### Task 3: Generate rich titles for historical pages
+
+**Files:**
+- Modify: `page-generator/html_generator.py:221-227`
+
+- [ ] **Step 1: Update the detail page template title**
+
+```python
+    template = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{display_name} Answer - {formatted_date} | Name That Yankee</title>
+    <link rel="stylesheet" href="style.css">
+```
+
+- [ ] **Step 2: Run backend tests**
+
+```bash
+pytest tests/unit/page_generator/test_html_generator.py -v
+```
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add page-generator/html_generator.py
+git commit -m "seo: generate rich titles for historical puzzle pages"
+```

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -91,7 +91,7 @@ function generateTeamChart(playerData) {
                 if (elements.length > 0) {
                     const clickedIndex = elements[0].index;
                     const teamAbbreviation = labels[clickedIndex];
-                    window.location.href = `/?search=${teamAbbreviation}`;
+                    window.location.href = `/?search=${encodeURIComponent(teamAbbreviation)}`;
                 }
             }
         }
@@ -128,7 +128,7 @@ function generateDecadeChart(playerData) {
                 if (elements.length > 0) {
                     const clickedIndex = elements[0].index;
                     const decade = originalDecades[clickedIndex]; // e.g., 1980
-                    window.location.href = `/?decade=${decade}`;
+                    window.location.href = `/?decade=${encodeURIComponent(decade)}`;
                 }
             }
         }

--- a/js/analytics.js
+++ b/js/analytics.js
@@ -91,7 +91,7 @@ function generateTeamChart(playerData) {
                 if (elements.length > 0) {
                     const clickedIndex = elements[0].index;
                     const teamAbbreviation = labels[clickedIndex];
-                    window.location.href = `index.html?search=${teamAbbreviation}`;
+                    window.location.href = `/?search=${teamAbbreviation}`;
                 }
             }
         }
@@ -128,7 +128,7 @@ function generateDecadeChart(playerData) {
                 if (elements.length > 0) {
                     const clickedIndex = elements[0].index;
                     const decade = originalDecades[clickedIndex]; // e.g., 1980
-                    window.location.href = `index.html?decade=${decade}`;
+                    window.location.href = `/?decade=${decade}`;
                 }
             }
         }

--- a/js/quiz.js
+++ b/js/quiz.js
@@ -24,7 +24,7 @@ export async function initQuiz() {
         localStorage.removeItem('nameThatYankeeCompletedPuzzles');
         localStorage.removeItem('nameThatYankeeScoreBreakdown');
         alert('Your score and quiz history have been reset.');
-        window.location.assign('index.html');
+        window.location.assign('/');
         return;
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "name": "Name That Yankee",
   "short_name": "NameThatYankee",
   "description": "Can you name this New York Yankee based on their career stats?",
-  "start_url": "/index.html",
+  "start_url": "/",
   "display": "standalone",
   "background_color": "#0C2340",
   "theme_color": "#0C2340",

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -223,7 +223,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Answer for {date_str} | Name That Yankee</title>
+    <title>{display_name} Answer - {formatted_date} | Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
     <link rel="shortcut icon" type="image/png" href="images/favicon.png">

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -223,7 +223,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>{display_name} Answer - {formatted_date} | Name That Yankee</title>
+    <title>{html.escape(display_name)} Answer - {formatted_date} | Name That Yankee</title>
     <link rel="stylesheet" href="style.css">
     <link rel="manifest" href="manifest.json">
     <link rel="shortcut icon" type="image/png" href="images/favicon.png">

--- a/quiz.html
+++ b/quiz.html
@@ -23,6 +23,10 @@
     <meta name="twitter:image" content="images/clue-2026-03-06.webp">
     
     <meta name="apple-mobile-web-app-title" content="NameThatYankee">
+    
+    <!-- Do not index interactive quiz states -->
+    <meta name="robots" content="noindex">
+    
     <script>
         (function() {
             const params = new URLSearchParams(window.location.search);
@@ -32,11 +36,6 @@
             if (date && /^\d{4}-\d{2}-\d{2}$/.test(date)) {
                 // Point canonical to the Reveal page
                 canonical.href = 'https://namethatyankeequiz.com/' + date;
-                // Add noindex for dated quiz pages
-                const meta = document.createElement('meta');
-                meta.name = 'robots';
-                meta.content = 'noindex';
-                document.head.appendChild(meta);
             } else {
                 canonical.href = 'https://namethatyankeequiz.com/quiz';
             }

--- a/test_seo_dynamic.py
+++ b/test_seo_dynamic.py
@@ -15,9 +15,9 @@ class TestDynamicSEO:
         canonical = page.locator('link[rel="canonical"]')
         expect(canonical).to_have_attribute("href", "https://namethatyankeequiz.com/quiz")
         
-        # Should NOT have noindex
+        # Should have noindex (we now static noindex all quiz pages)
         noindex = page.locator('meta[name="robots"][content="noindex"]')
-        expect(noindex).to_have_count(0)
+        expect(noindex).to_have_count(1)
 
     def test_quiz_canonical_with_date(self, page: Page):
         test_date = "2025-07-23"

--- a/tests/test_seo_task_1.py
+++ b/tests/test_seo_task_1.py
@@ -1,0 +1,29 @@
+# ABOUTME: Test for SEO Remediation Task 1: Static noindex in quiz.html
+import pytest
+from bs4 import BeautifulSoup
+import os
+
+def test_quiz_has_static_noindex():
+    quiz_path = os.path.join(os.path.dirname(__file__), '..', 'quiz.html')
+    with open(quiz_path, 'r') as f:
+        html = f.read()
+    
+    soup = BeautifulSoup(html, 'html.parser')
+    robots_meta = soup.find('meta', attrs={'name': 'robots', 'content': 'noindex'})
+    
+    assert robots_meta is not None, "quiz.html should have a static <meta name='robots' content='noindex'>"
+    assert robots_meta.parent.name == 'head', "robots meta tag should be in the head section"
+
+def test_quiz_has_simplified_canonical_script():
+    quiz_path = os.path.join(os.path.dirname(__file__), '..', 'quiz.html')
+    with open(quiz_path, 'r') as f:
+        html = f.read()
+    
+    # Check if the old JS-based noindex injection is gone
+    assert 'const meta = document.createElement(\'meta\');' not in html
+    assert 'meta.name = \'robots\';' not in html
+    assert 'meta.content = \'noindex\';' not in html
+    
+    # Check for the presence of the canonical script
+    assert 'const canonical = document.createElement(\'link\');' in html
+    assert 'canonical.rel = \'canonical\';' in html

--- a/tests/unit/page_generator/test_html_generator.py
+++ b/tests/unit/page_generator/test_html_generator.py
@@ -33,7 +33,7 @@ def test_build_detail_page_html(sample_player_data):
     soup = BeautifulSoup(html_content, "html.parser")
     
     # Check title and header match proper date
-    assert f"Answer for {date_str}" in soup.title.string
+    assert f"Derek Jeter \"The Captain\" Answer - {formatted_date}" in soup.title.string
     assert f"The answer for {formatted_date} is..." in soup.find("h1").string
     
     # Check name and nickname logic maps


### PR DESCRIPTION
## Summary
- Added static `noindex` to `quiz.html` to prevent indexing of interactive states.
- Normalized internal links and redirects to point to the root domain (`/`) instead of `index.html`.
- Updated the page generator to create richer, descriptive titles for historical puzzle pages.
- Updated test suite to reflect new SEO requirements.

## Test Plan
- [x] Verified full test suite passes (`./run_tests.sh`).
- [x] Confirmed rich title generation in backend unit tests.
- [x] Confirmed presence of static `noindex` in E2E tests.