### PR TITLE
fix(seo): resolve robots.txt indexing conflict

### DIFF
--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -2,6 +2,12 @@
 
 ## Journal
 
+### 2026-04-30: SEO Indexing Fix - \"The Visibility Paradox\"
+*   **Conflict Resolution:** Resolved \"Indexed, though blocked by robots.txt\" warnings in Search Console by removing the `Disallow` rule for dated quiz URLs. This allows crawlers to access the pages and discover the `noindex` instruction.
+*   **Directive Hardening:** Strengthened the `robots` meta tag in `quiz.html` to `noindex, nofollow, noarchive, nosnippet` to ensure search engines drop existing indexed versions and prevent caching.
+*   **Verification Standards:** Added a new E2E test to `test_yankee_site.py` to verify static `noindex` presence and updated `test_seo_dynamic.py` with regex-based matching for future-proof validation.
+*   **Verification:** Confirmed 100% pass rate across the full regression suite.
+
 ### 2026-04-29: Quiz Generation & Chart Restoration - \"Visual Integrity\"
 *   **Daily Quizzes:** Generated new trivia puzzles for 2026-04-28 (Steve Hamilton) and 2026-04-29 (John Charles Ellis). Updated the main gallery and `stats_summary.json`.
 *   **Bug Fix (Career Arc Chart):** Identified that the \"Career Arc by WAR\" chart was failing to render due to a missing `js/team_colors.js` file. Reconstructed the file from git history (Commit `aa1fa16`) and restored it to the codebase.

--- a/quiz.html
+++ b/quiz.html
@@ -25,7 +25,7 @@
     <meta name="apple-mobile-web-app-title" content="NameThatYankee">
     
     <!-- Do not index interactive quiz states -->
-    <meta name="robots" content="noindex">
+    <meta name="robots" content="noindex, nofollow, noarchive, nosnippet">
     
     <script>
         (function() {

--- a/robots.txt
+++ b/robots.txt
@@ -1,6 +1,8 @@
 # robots.txt for https://namethatyankeequiz.com
 User-agent: *
 Allow: /
-Disallow: /*?date=
+
+# Note: We do not Disallow /*?date= here because we want Google to crawl those pages 
+# and see the 'noindex' meta tag in quiz.html, which ensures they are removed from the index.
 
 Sitemap: https://namethatyankeequiz.com/sitemap.xml

--- a/test_seo_dynamic.py
+++ b/test_seo_dynamic.py
@@ -16,8 +16,8 @@ class TestDynamicSEO:
         expect(canonical).to_have_attribute("href", "https://namethatyankeequiz.com/quiz")
         
         # Should have noindex (we now static noindex all quiz pages)
-        noindex = page.locator('meta[name="robots"][content="noindex"]')
-        expect(noindex).to_have_count(1)
+        noindex = page.locator('meta[name="robots"]')
+        expect(noindex).to_have_attribute("content", re.compile(r"noindex"))
 
     def test_quiz_canonical_with_date(self, page: Page):
         test_date = "2025-07-23"
@@ -30,5 +30,5 @@ class TestDynamicSEO:
         expect(canonical).to_have_attribute("href", f"https://namethatyankeequiz.com/{test_date}")
         
         # Should have noindex
-        noindex = page.locator('meta[name="robots"][content="noindex"]')
-        expect(noindex).to_be_attached()
+        noindex = page.locator('meta[name="robots"]')
+        expect(noindex).to_have_attribute("content", re.compile(r"noindex"))

--- a/test_yankee_site.py
+++ b/test_yankee_site.py
@@ -108,6 +108,13 @@ class TestCleanURLNavigation:
         # Should be redirected to quiz
         expect(page).to_have_url(re.compile(f".*/quiz\\?date={test_slug}$"))
 
+    def test_quiz_page_noindex(self, page: Page):
+        """Verify that the interactive quiz page has noindex meta tag."""
+        page.goto(f"{BASE_URL}quiz?date=2025-07-23")
+        robots_meta = page.locator('meta[name="robots"]')
+        expect(robots_meta).to_have_attribute("content", re.compile(r"noindex"))
+        expect(robots_meta).to_have_attribute("content", re.compile(r"nofollow"))
+
     def test_gallery_cards_have_required_elements(self, page: Page):
         page.goto(BASE_URL)
         


### PR DESCRIPTION
This PR resolves the 'Indexed, though blocked by robots.txt' warnings by allowing Google to crawl quiz pages so it can see the 'noindex' tag. It also strengthens the 'noindex' tag with 'noarchive' and 'nosnippet' directives.