### PR TITLE
feat: support multiple nicknames as alternate correct guesses

### DIFF
--- a/js/quiz.js
+++ b/js/quiz.js
@@ -354,7 +354,7 @@ export async function initQuiz() {
                         clues: data.hints 
                     } 
                 });
-                engine = new QuizEngine(data.answer, data.hints, data.nickname || '');
+                engine = new QuizEngine(data.answer, data.hints, data.nicknames || data.nickname || []);
                 setupEventListeners();
             } else {
                 throw new Error('Quiz data not found on detail page.');

--- a/js/quizEngine.js
+++ b/js/quizEngine.js
@@ -39,12 +39,12 @@ export function calculateScore(index) {
 
 export class QuizEngine {
     #answer;
-    #nickname;
+    #nicknames;
 
-    constructor(answer, clues, nickname = "") {
+    constructor(answer, clues, nicknames = []) {
         if (!answer) throw new Error("QuizEngine requires a valid answer");
         this.#answer = answer;
-        this.#nickname = nickname;
+        this.#nicknames = Array.isArray(nicknames) ? nicknames : (nicknames ? [nicknames] : []);
         this.clues = clues;
         this.currentClueIndex = 0;
         this.isComplete = false;
@@ -70,9 +70,9 @@ export class QuizEngine {
 
         const normalizedGuess = this.normalize(guess);
         const normalizedAnswer = this.normalize(this.#answer);
-        const normalizedNickname = this.normalize(this.#nickname);
+        const isNicknameMatch = this.#nicknames.some(n => this.normalize(n) === normalizedGuess);
 
-        if (normalizedGuess === normalizedAnswer || (normalizedNickname && normalizedGuess === normalizedNickname)) {
+        if (normalizedGuess === normalizedAnswer || isNicknameMatch) {
             this.isComplete = true;
             return {
                 status: 'CORRECT',

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -12,14 +12,18 @@ from typing import Dict, List
 def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str) -> str:
     """Builds and returns the HTML string for the detail page."""
     name = player_data.get('name', 'N/A')
-    nickname = player_data.get('nickname', '')
+    nicknames = player_data.get('nicknames', [])
+    if not nicknames:
+        single = player_data.get('nickname', '')
+        nicknames = [single] if single else []
     facts = player_data.get('facts', [])
     followup_qa = player_data.get('followup_qa', [])
     career_totals_data = player_data.get('career_totals', {})
     yearly_war_data = player_data.get('yearly_war', [])
     
-    # Escape name and nickname for HTML safety
-    display_name = html.escape(f'{name} "{nickname}"' if nickname else name)
+    # Display uses only the primary nickname for the h2 heading
+    primary_nickname = nicknames[0] if nicknames else ''
+    display_name = html.escape(f'{name} "{primary_nickname}"' if primary_nickname else name)
     facts_html = "\n".join([f"                        <li>{fact}</li>" for fact in facts])
 
     followup_section_html = ""
@@ -83,7 +87,7 @@ def build_detail_page_html(player_data: dict, date_str: str, formatted_date: str
         search_data = {'teams': list(all_teams), 'years': sorted(list(all_years))}
         search_data_html = f'<div id="search-data" style="display:none;">{json.dumps(search_data)}</div>'
 
-        quiz_data = {"answer": name, "nickname": nickname, "hints": facts}
+        quiz_data = {"answer": name, "nicknames": nicknames, "hints": facts}
         quiz_data_html = f'<div id="quiz-data" style="display:none;">{json.dumps(quiz_data)}</div>'
 
         chart_html = f"""

--- a/tests/js/quiz.test.js
+++ b/tests/js/quiz.test.js
@@ -33,17 +33,17 @@ vi.mock('../../js/quizEngine.js', () => {
             return [];
         }),
         QuizEngine: class {
-            constructor(answer, clues, nickname = "") {
+            constructor(answer, clues, nicknames = []) {
                 this.answer = answer;
                 this.clues = clues;
-                this.nickname = nickname;
+                this.nicknames = Array.isArray(nicknames) ? nicknames : (nicknames ? [nicknames] : []);
                 this.currentClueIndex = 0;
             }
             submitGuess(guess, normalizedPlayerSet) {
                 const g = guess.toLowerCase().trim();
                 const a = this.answer.toLowerCase().trim();
-                const n = this.nickname ? this.nickname.toLowerCase().trim() : '';
-                if (g === a || (n && g === n)) {
+                const isNicknameMatch = this.nicknames.some(n => n.toLowerCase().trim() === g);
+                if (g === a || isNicknameMatch) {
                     return { status: 'CORRECT', score: calculateScore(this.currentClueIndex), clueIndex: this.currentClueIndex, gameOver: true };
                 }
                 // For testing purposes, treat specific names as valid even if normalizedPlayerSet is empty in JSDOM

--- a/tests/js/quizEngine.test.js
+++ b/tests/js/quizEngine.test.js
@@ -38,6 +38,36 @@ describe('QuizEngine', () => {
             expect(engine.isComplete).toBe(true);
         });
 
+        it('should accept any nickname from an array as correct', () => {
+            const engineWithNicknames = new QuizEngine(answer, clues, ["Captain", "Mr. November"]);
+            const result = engineWithNicknames.submitGuess("Mr. November", normalizedPlayerSet);
+            expect(result.status).toBe('CORRECT');
+            expect(result.score).toBe(10);
+        });
+
+        it('should accept the first nickname from an array as correct', () => {
+            const engineWithNicknames = new QuizEngine(answer, clues, ["Captain", "Mr. November"]);
+            const result = engineWithNicknames.submitGuess("Captain", normalizedPlayerSet);
+            expect(result.status).toBe('CORRECT');
+        });
+
+        it('should accept a single nickname string for backward compatibility', () => {
+            const engineWithNickname = new QuizEngine(answer, clues, "Captain");
+            const result = engineWithNickname.submitGuess("Captain", normalizedPlayerSet);
+            expect(result.status).toBe('CORRECT');
+        });
+
+        it('should work with empty nicknames array', () => {
+            const engineNoNicknames = new QuizEngine(answer, clues, []);
+            const result = engineNoNicknames.submitGuess("Not Derek", normalizedPlayerSet);
+            expect(result.status).not.toBe('CORRECT');
+        });
+
+        it('should work with no nicknames argument', () => {
+            const result = engine.submitGuess("Captain", normalizedPlayerSet);
+            expect(result.status).not.toBe('CORRECT');
+        });
+
         it('should return INCORRECT_VALID_PLAYER for a wrong but valid player', () => {
             const result = engine.submitGuess("Alex Rodriguez", normalizedPlayerSet);
             expect(result.status).toBe('INCORRECT_VALID_PLAYER');

--- a/tests/js/scoreBreakdown.test.js
+++ b/tests/js/scoreBreakdown.test.js
@@ -30,17 +30,17 @@ vi.mock('../../js/quizEngine.js', () => {
         calculateScore: vi.fn(calculateScore),
         getAutocompleteSuggestions: vi.fn(() => []),
         QuizEngine: class {
-            constructor(answer, clues, nickname = "") {
+            constructor(answer, clues, nicknames = []) {
                 this.answer = answer;
                 this.clues = clues;
-                this.nickname = nickname;
+                this.nicknames = Array.isArray(nicknames) ? nicknames : (nicknames ? [nicknames] : []);
                 this.currentClueIndex = 0;
             }
             submitGuess(guess, normalizedPlayerSet) {
                 const g = guess.toLowerCase().trim();
                 const a = this.answer.toLowerCase().trim();
-                const n = this.nickname ? this.nickname.toLowerCase().trim() : '';
-                if (g === a || (n && g === n)) {
+                const isNicknameMatch = this.nicknames.some(n => n.toLowerCase().trim() === g);
+                if (g === a || isNicknameMatch) {
                     return { status: 'CORRECT', score: calculateScore(this.currentClueIndex), clueIndex: this.currentClueIndex, gameOver: true };
                 }
                 // Mock behavior for testing: allow specific names or use Set if available

--- a/tests/unit/page_generator/test_html_generator.py
+++ b/tests/unit/page_generator/test_html_generator.py
@@ -56,6 +56,6 @@ def test_build_detail_page_html(sample_player_data):
     import json
     quiz_data = json.loads(quiz_data_div.string)
     assert quiz_data["answer"] == "Derek Jeter"
-    assert quiz_data["nickname"] == "The Captain"
+    assert quiz_data["nicknames"] == ["The Captain"]
     assert "Hit a home run for his 3000th hit" in quiz_data["hints"]
 


### PR DESCRIPTION
## Summary

Extends the quiz engine to accept multiple nicknames per player, enabling easter egg alternate answers.

## Changes

- **`QuizEngine`** — `#nickname` (string) → `#nicknames` (array). Constructor normalizes input (string or array). `submitGuess` checks guess against all entries via `.some()`.
- **`quiz.js`** — Reads `data.nicknames` (array) first, falls back to `data.nickname` (string) for backward compatibility with existing HTML pages.
- **`html_generator.py`** — Outputs `"nicknames": [...]` array in quiz-data JSON. Accepts both `nicknames` (list) and `nickname` (string) from player data input.
- **Tests** — 5 new test cases covering array nicknames, single-string backward compat, and edge cases. Updated mock QuizEngine in `quiz.test.js` and `scoreBreakdown.test.js`.

## Backward Compatibility

Existing HTML pages with `"nickname": "string"` continue to work without modification. New pages generated going forward use the `"nicknames": [...]` format.

## Example

```json
{"answer": "Mickey Mantle", "nicknames": ["The Mick", "Commerce Comet"], "hints": [...]}
```

## Testing

All 188 tests pass (99 JS + 89 Python + E2E).