### PR TITLE
feat: add --add-nickname CLI for easter egg answers

### DIFF
--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -516,7 +516,7 @@ def add_nickname_to_page(project_dir: Path, date_str: str, nickname: str) -> boo
     quiz_data['nicknames'] = nicknames
 
     # Replace only the quiz-data div content
-    quiz_data_div.string = json.dumps(quiz_data)
+    quiz_data_div.string = json.dumps(quiz_data, indent=4)
     page_path.write_text(str(soup), encoding='utf-8')
     print(f"✅ Added \"{nickname}\" to {page_path.name} (now {len(nicknames)} nickname(s))")
     return True

--- a/page-generator/html_generator.py
+++ b/page-generator/html_generator.py
@@ -478,3 +478,45 @@ def rebuild_index_page(project_dir: Path):
     with open(stats_file, 'w', encoding='utf-8') as f:
         json.dump(stats_summary, f, indent=4)
     print(f"✅ {stats_file.name} updated with {len(stats_summary)} entries.")
+
+
+def add_nickname_to_page(project_dir: Path, date_str: str, nickname: str) -> bool:
+    """Adds a nickname to an existing puzzle page's quiz-data JSON.
+
+    Returns True if the nickname was added, False if the page doesn't exist
+    or the nickname is already present.
+    """
+    page_path = project_dir / f"{date_str}.html"
+    if not page_path.exists():
+        print(f"❌ Page not found: {page_path}")
+        return False
+
+    html_content = page_path.read_text(encoding='utf-8')
+    soup = BeautifulSoup(html_content, 'html.parser')
+    quiz_data_div = soup.find(id='quiz-data')
+    if not quiz_data_div or not quiz_data_div.string:
+        print(f"❌ No quiz-data found in {page_path.name}")
+        return False
+
+    quiz_data = json.loads(quiz_data_div.string)
+
+    # Normalize old format to new format
+    nicknames = quiz_data.get('nicknames', [])
+    if not nicknames:
+        old = quiz_data.get('nickname', '')
+        nicknames = [old] if old else []
+    quiz_data.pop('nickname', None)
+
+    # Check for duplicates (case-insensitive)
+    if any(n.lower() == nickname.lower() for n in nicknames):
+        print(f"⚠️  \"{nickname}\" is already a nickname for this puzzle.")
+        return False
+
+    nicknames.append(nickname)
+    quiz_data['nicknames'] = nicknames
+
+    # Replace only the quiz-data div content
+    quiz_data_div.string = json.dumps(quiz_data)
+    page_path.write_text(str(soup), encoding='utf-8')
+    print(f"✅ Added \"{nickname}\" to {page_path.name} (now {len(nicknames)} nickname(s))")
+    return True

--- a/page-generator/main.py
+++ b/page-generator/main.py
@@ -713,7 +713,9 @@ Notes:
         if not nickname:
             print("❌ Nickname cannot be empty.")
             exit(1)
-        html_generator.add_nickname_to_page(project_dir, date_str, nickname)
+        success = html_generator.add_nickname_to_page(project_dir, date_str, nickname)
+        if not success:
+            exit(1)
         exit()
 
     # Handle standalone image search

--- a/page-generator/main.py
+++ b/page-generator/main.py
@@ -636,6 +636,10 @@ Options:
   --rebuild-index      Rebuild and re-sort index.html and update 
                        stats_summary.json from all available clue images.
 
+  --add-nickname       [date] [nickname]
+                       Add an alternate accepted answer (nickname/easter egg)
+                       to an existing puzzle page. Prompts if not provided.
+
   -h, --help            Show this help message and exit.
 
 Interactive prompts (normal generation mode):
@@ -681,6 +685,7 @@ Notes:
     config_mode = "--config" in sys.argv
     regenerate_mode = "--regenerate-facts" in sys.argv
     rebuild_index_mode = "--rebuild-index" in sys.argv
+    add_nickname_mode = "--add-nickname" in sys.argv
 
     # Handle automation configuration
     if config_mode and AUTOMATION_AVAILABLE:
@@ -696,6 +701,19 @@ Notes:
     if rebuild_index_mode:
         project_dir = get_project_directory(config)
         html_generator.rebuild_index_page(project_dir)
+        exit()
+
+    # Handle adding a nickname to an existing puzzle
+    if add_nickname_mode:
+        project_dir = get_project_directory(config)
+        flag_idx = sys.argv.index("--add-nickname")
+        remaining = sys.argv[flag_idx + 1:]
+        date_str = remaining[0] if len(remaining) >= 1 else input("Enter puzzle date (YYYY-MM-DD): ").strip()
+        nickname = remaining[1] if len(remaining) >= 2 else input("Enter nickname to add: ").strip()
+        if not nickname:
+            print("❌ Nickname cannot be empty.")
+            exit(1)
+        html_generator.add_nickname_to_page(project_dir, date_str, nickname)
         exit()
 
     # Handle standalone image search

--- a/tests/unit/page_generator/test_html_generator.py
+++ b/tests/unit/page_generator/test_html_generator.py
@@ -1,4 +1,5 @@
 import pytest  # type: ignore
+import json
 from bs4 import BeautifulSoup  # type: ignore
 import html_generator  # type: ignore
 
@@ -59,3 +60,67 @@ def test_build_detail_page_html(sample_player_data):
     assert quiz_data["nicknames"] == ["The Captain"]
     assert "Hit a home run for his 3000th hit" in quiz_data["hints"]
 
+
+class TestAddNicknameToPage:
+    """Tests for adding nicknames to existing puzzle pages."""
+
+    def _create_page_with_quiz_data(self, tmp_path, date_str, quiz_data):
+        """Helper to create a minimal HTML page with quiz-data."""
+        page = tmp_path / f"{date_str}.html"
+        page.write_text(
+            f'<html><body>'
+            f'<div id="quiz-data" style="display:none;">'
+            f'{json.dumps(quiz_data)}'
+            f'</div></body></html>'
+        )
+        return page
+
+    def test_adds_nickname_to_page_with_nicknames_array(self, tmp_path):
+        quiz_data = {"answer": "Derek Jeter", "nicknames": ["Captain"], "hints": ["Clue 1"]}
+        self._create_page_with_quiz_data(tmp_path, "2025-01-01", quiz_data)
+
+        result = html_generator.add_nickname_to_page(tmp_path, "2025-01-01", "Mr. November")
+
+        assert result is True
+        page = tmp_path / "2025-01-01.html"
+        soup = BeautifulSoup(page.read_text(), "html.parser")
+        updated = json.loads(soup.find(id="quiz-data").string)
+        assert updated["nicknames"] == ["Captain", "Mr. November"]
+
+    def test_adds_nickname_to_page_with_old_format(self, tmp_path):
+        quiz_data = {"answer": "Derek Jeter", "nickname": "Captain", "hints": ["Clue 1"]}
+        self._create_page_with_quiz_data(tmp_path, "2025-01-01", quiz_data)
+
+        result = html_generator.add_nickname_to_page(tmp_path, "2025-01-01", "Mr. November")
+
+        assert result is True
+        page = tmp_path / "2025-01-01.html"
+        soup = BeautifulSoup(page.read_text(), "html.parser")
+        updated = json.loads(soup.find(id="quiz-data").string)
+        assert updated["nicknames"] == ["Captain", "Mr. November"]
+        assert "nickname" not in updated
+
+    def test_rejects_duplicate_nickname(self, tmp_path):
+        quiz_data = {"answer": "Derek Jeter", "nicknames": ["Captain"], "hints": ["Clue 1"]}
+        self._create_page_with_quiz_data(tmp_path, "2025-01-01", quiz_data)
+
+        result = html_generator.add_nickname_to_page(tmp_path, "2025-01-01", "Captain")
+
+        assert result is False
+
+    def test_returns_false_for_missing_page(self, tmp_path):
+        result = html_generator.add_nickname_to_page(tmp_path, "2099-01-01", "Captain")
+
+        assert result is False
+
+    def test_adds_nickname_to_page_with_no_existing_nicknames(self, tmp_path):
+        quiz_data = {"answer": "Derek Jeter", "nickname": "", "hints": ["Clue 1"]}
+        self._create_page_with_quiz_data(tmp_path, "2025-01-01", quiz_data)
+
+        result = html_generator.add_nickname_to_page(tmp_path, "2025-01-01", "Captain")
+
+        assert result is True
+        page = tmp_path / "2025-01-01.html"
+        soup = BeautifulSoup(page.read_text(), "html.parser")
+        updated = json.loads(soup.find(id="quiz-data").string)
+        assert updated["nicknames"] == ["Captain"]


### PR DESCRIPTION
## Summary

Adds a CLI command to manually add alternate accepted answers (easter eggs) to existing puzzle pages.

## Usage

```bash
# Inline
python page-generator/main.py --add-nickname 2025-09-07 "Donnie Baseball"

# Interactive (prompts for date and nickname)
python page-generator/main.py --add-nickname
```

## What it does

- Reads the target page's `quiz-data` JSON
- Migrates old `"nickname": "string"` format to `"nicknames": [...]` if needed
- Appends the new nickname (with case-insensitive duplicate prevention)
- Writes the updated HTML back

## Changes

- **`html_generator.py`** — New `add_nickname_to_page()` function
- **`main.py`** — `--add-nickname` flag with inline or interactive argument handling
- **Tests** — 5 new tests covering array append, old-format migration, duplicates, missing pages, and empty nicknames

## Testing

All 193 tests pass.