### PR TITLE
feat: Google Indexing API integration

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,19 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Download Pages artifact for indexing
+        if: success()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: github-pages
+          path: ./_site
+
+      - name: Write Google Indexing credentials
+        if: success()
+        continue-on-error: true
+        run: echo '${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}' > /tmp/google-indexing-creds.json
+
       - name: Submit new URLs to Google Indexing API
         if: success()
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -149,7 +149,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: indexing-state
-          path: .indexing_state.json
+          path: .
           merge-multiple: false
 
       - name: Download Pages artifact for indexing
@@ -165,7 +165,7 @@ jobs:
         continue-on-error: true
         env:
           CREDS: ${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}
-        run: echo "$CREDS" > /tmp/google-indexing-creds.json
+        run: printf "%s" "$CREDS" > /tmp/google-indexing-creds.json
 
       - name: Submit new URLs to Google Indexing API
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,10 @@
 # deploy.yml
+#
+# Required secrets:
+#   GOOGLE_INDEXING_CREDENTIALS: GCP service account JSON key file
+#     - Service account must have Indexing API enabled
+#     - Service account email must be owner in Google Search Console
+#     - Get from: https://console.cloud.google.com/iam-admin/serviceaccounts
 
 name: Build and Deploy Site
 
@@ -132,4 +138,22 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4
+
+      - name: Submit new URLs to Google Indexing API
+        if: success()
+        continue-on-error: true
+        run: |
+          pip install google-api-python-client google-auth
+          python -m page_generator.indexing.submit_urls \
+            --credentials /tmp/google-indexing-creds.json \
+            --sitemap ./_site/sitemap.xml \
+            --state-file .indexing_state.json
+
+      - name: Write indexing state
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: indexing-state
+          path: .indexing_state.json
+          retention-days: 90

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,6 +143,15 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Download previous indexing state
+        if: success()
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: indexing-state
+          path: .indexing_state.json
+          merge-multiple: false
+
       - name: Download Pages artifact for indexing
         if: success()
         continue-on-error: true
@@ -154,14 +163,16 @@ jobs:
       - name: Write Google Indexing credentials
         if: success()
         continue-on-error: true
-        run: echo '${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}' > /tmp/google-indexing-creds.json
+        env:
+          CREDS: ${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}
+        run: echo "$CREDS" > /tmp/google-indexing-creds.json
 
       - name: Submit new URLs to Google Indexing API
         if: success()
         continue-on-error: true
         run: |
-          pip install google-api-python-client google-auth
-          python -m page_generator.indexing.submit_urls \
+          pip install -r requirements.txt
+          PYTHONPATH=./page-generator python -m indexing.submit_urls \
             --credentials /tmp/google-indexing-creds.json \
             --sitemap ./_site/sitemap.xml \
             --state-file .indexing_state.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -136,6 +136,9 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
@@ -152,6 +155,7 @@ jobs:
 
       - name: Write indexing state
         if: success()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: indexing-state

--- a/README_AUTOMATION.md
+++ b/README_AUTOMATION.md
@@ -158,6 +158,45 @@ The automation is fully backward compatible:
 - No breaking changes to existing API
 - Automation as opt-in feature
 
+## Google Indexing API Integration
+
+New pages are automatically submitted to Google for indexing after deployment.
+
+### Setup Requirements
+
+1. **Google Cloud Service Account:**
+   - Create at https://console.cloud.google.com/iam-admin/serviceaccounts
+   - Enable "Indexing API" in the service account's API list
+   - Download the JSON key file
+
+2. **Google Search Console:**
+   - Add the service account email as an **Owner** in Search Console
+   - Go to Settings > Users and permissions > Add user
+
+3. **GitHub Secrets:**
+   - Add `GOOGLE_INDEXING_CREDENTIALS` with the contents of the JSON key file
+
+### How It Works
+
+1. After a successful deploy, the workflow parses the sitemap
+2. New URLs (not previously submitted) are sent to Google Indexing API
+3. Submission state is stored as a GitHub artifact for deduplication
+
+### Manual Submission
+
+To manually submit URLs:
+
+```bash
+python page-generator/main.py --submit-indexing \
+    --credentials /path/to/creds.json \
+    --sitemap ./_site/sitemap.xml
+```
+
+### Quotas
+
+- Google Indexing API limit: 200 requests per day per project
+- State file prevents duplicate submissions
+
 ## Troubleshooting
 
 ### Common Issues

--- a/page-generator/indexing/__init__.py
+++ b/page-generator/indexing/__init__.py
@@ -1,0 +1,1 @@
+"""Google Indexing API integration for faster page indexing."""

--- a/page-generator/indexing/__init__.py
+++ b/page-generator/indexing/__init__.py
@@ -1,1 +1,3 @@
+# ABOUTME: Initialization for the indexing package.
+# ABOUTME: Provides Google Indexing API integration components.
 """Google Indexing API integration for faster page indexing."""

--- a/page-generator/indexing/google_indexing.py
+++ b/page-generator/indexing/google_indexing.py
@@ -1,0 +1,79 @@
+# ABOUTME: Google Indexing API client for submitting URLs to Google.
+# ABOUTME: Handles authentication via service account and URL submission.
+"""Google Indexing API client for requesting indexing of URLs.
+
+Usage:
+    from indexing import GoogleIndexingClient
+
+    client = GoogleIndexingClient.from_credentials_file("path/to/creds.json")
+    result = client.submit_url("https://namethatyankeequiz.com/2026-07-20")
+
+Requires:
+    - google-api-python-client
+    - google-auth
+    - Service account with Indexing API enabled
+    - Service account email must be owner in Google Search Console
+"""
+
+import logging
+from pathlib import Path
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+logger = logging.getLogger(__name__)
+
+SCOPES = ["https://www.googleapis.com/auth/indexing"]
+INDEXING_API_NAME = "indexing"
+INDEXING_API_VERSION = "v3"
+
+
+class GoogleIndexingClient:
+    """Client for Google Indexing API."""
+
+    def __init__(self, credentials_file: str | Path):
+        """Initialize client with path to service account credentials JSON.
+
+        Args:
+            credentials_file: Path to the GCP service account JSON key file.
+        """
+        self.credentials_file = Path(credentials_file)
+        self.service = self._build_service()
+
+    def _build_service(self):
+        """Build and return the Indexing API service object."""
+        credentials = service_account.Credentials.from_service_account_file(
+            str(self.credentials_file), scopes=SCOPES
+        )
+        return build(INDEXING_API_NAME, INDEXING_API_VERSION, credentials=credentials)
+
+    def submit_url(self, url: str) -> dict:
+        """Submit a URL to Google for indexing.
+
+        Args:
+            url: The full URL to submit (e.g., "https://namethatyankeequiz.com/2026-07-20")
+
+        Returns:
+            dict: The API response containing URL notification metadata.
+
+        Raises:
+            Exception: If the API call fails.
+        """
+        body = {"url": url, "type": "URL_UPDATED"}
+        logger.info(f"Submitting URL to Indexing API: {url}")
+
+        response = self.service.urlNotifications().publish(body=body).execute()
+        logger.info(f"Indexing API response: {response}")
+        return response
+
+    @classmethod
+    def from_credentials_file(cls, credentials_file: str | Path) -> "GoogleIndexingClient":
+        """Create client from credentials file path.
+
+        Args:
+            credentials_file: Path to the GCP service account JSON key file.
+
+        Returns:
+            GoogleIndexingClient: Initialized client instance.
+        """
+        return cls(credentials_file)

--- a/page-generator/indexing/submit_urls.py
+++ b/page-generator/indexing/submit_urls.py
@@ -1,0 +1,158 @@
+# ABOUTME: CLI script to submit new URLs to Google Indexing API.
+# ABOUTME: Reads sitemap, filters new pages, and submits to Indexing API.
+"""Submit new URLs to Google Indexing API.
+
+Usage:
+    python -m page_generator.indexing.submit_urls \
+        --credentials /path/to/creds.json \
+        --sitemap /path/to/sitemap.xml
+
+This script:
+1. Parses the sitemap to find all URLs
+2. Filters out non-page URLs and already-indexed URLs
+3. Submits new URLs to Google Indexing API
+"""
+
+import argparse
+import json
+import logging
+from pathlib import Path
+from xml.etree import ElementTree
+
+from indexing.google_indexing import GoogleIndexingClient
+
+logger = logging.getLogger(__name__)
+
+SITEMAP_NS = "http://www.sitemaps.org/schemas/sitemap/0.9"
+EXCLUDE_PATTERNS = ["/images/", "/docs/", ".css", ".js", ".webp", ".png", ".jpg"]
+
+
+def parse_sitemap(sitemap_path: Path) -> list[str]:
+    """Parse sitemap XML and return list of URLs.
+
+    Args:
+        sitemap_path: Path to the sitemap.xml file.
+
+    Returns:
+        List of URLs found in the sitemap.
+
+    Raises:
+        FileNotFoundError: If sitemap file doesn't exist.
+    """
+    if not sitemap_path.exists():
+        raise FileNotFoundError(f"Sitemap not found: {sitemap_path}")
+
+    tree = ElementTree.parse(sitemap_path)
+    root = tree.getroot()
+
+    urls = []
+    for url_elem in root.findall(f"{{{SITEMAP_NS}}}url"):
+        loc = url_elem.find(f"{{{SITEMAP_NS}}}loc")
+        if loc is not None and loc.text:
+            urls.append(loc.text)
+
+    return urls
+
+
+def filter_new_urls(urls: list[str], indexed_urls: set[str]) -> list[str]:
+    """Filter URLs to only include new, indexable pages.
+
+    Args:
+        urls: List of all URLs from sitemap.
+        indexed_urls: Set of URLs already submitted for indexing.
+
+    Returns:
+        List of new URLs that should be submitted.
+    """
+    new_urls = []
+    for url in urls:
+        # Skip if already indexed
+        if url in indexed_urls:
+            continue
+
+        # Skip root URL
+        if url.rstrip("/") == "https://namethatyankeequiz.com":
+            continue
+
+        # Skip non-page URLs
+        if any(pattern in url for pattern in EXCLUDE_PATTERNS):
+            continue
+
+        new_urls.append(url)
+
+    return new_urls
+
+
+def main():
+    """Main entry point for the submission script."""
+    parser = argparse.ArgumentParser(description="Submit URLs to Google Indexing API")
+    parser.add_argument(
+        "--credentials",
+        required=True,
+        help="Path to GCP service account credentials JSON",
+    )
+    parser.add_argument(
+        "--sitemap",
+        required=True,
+        help="Path to sitemap.xml",
+    )
+    parser.add_argument(
+        "--state-file",
+        default=".indexing_state.json",
+        help="Path to state file tracking submitted URLs",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview URLs without submitting",
+    )
+    args = parser.parse_args()
+
+    # Load state
+    state_path = Path(args.state_file)
+    if state_path.exists():
+        state = json.loads(state_path.read_text())
+        indexed_urls = set(state.get("indexed_urls", []))
+    else:
+        indexed_urls = set()
+
+    # Parse sitemap
+    sitemap_path = Path(args.sitemap)
+    all_urls = parse_sitemap(sitemap_path)
+    logger.info(f"Found {len(all_urls)} URLs in sitemap")
+
+    # Filter new URLs
+    new_urls = filter_new_urls(all_urls, indexed_urls)
+    logger.info(f"Found {len(new_urls)} new URLs to submit")
+
+    if not new_urls:
+        print("No new URLs to submit.")
+        return
+
+    if args.dry_run:
+        print("Dry run - URLs that would be submitted:")
+        for url in new_urls:
+            print(f"  - {url}")
+        return
+
+    # Submit URLs
+    client = GoogleIndexingClient(args.credentials)
+    submitted = []
+
+    for url in new_urls:
+        try:
+            client.submit_url(url)
+            submitted.append(url)
+            logger.info(f"Successfully submitted: {url}")
+        except Exception as e:
+            logger.error(f"Failed to submit {url}: {e}")
+
+    # Update state
+    indexed_urls.update(submitted)
+    state_path.write_text(json.dumps({"indexed_urls": sorted(indexed_urls)}, indent=2))
+    print(f"Submitted {len(submitted)} URLs for indexing.")
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    main()

--- a/page-generator/indexing/submit_urls.py
+++ b/page-generator/indexing/submit_urls.py
@@ -17,6 +17,7 @@ import argparse
 import json
 import logging
 from pathlib import Path
+from urllib.parse import urlparse
 from xml.etree import ElementTree
 
 from indexing.google_indexing import GoogleIndexingClient
@@ -71,7 +72,8 @@ def filter_new_urls(urls: list[str], indexed_urls: set[str]) -> list[str]:
             continue
 
         # Skip root URL
-        if url.rstrip("/") == "https://namethatyankeequiz.com":
+        parsed_url = urlparse(url)
+        if parsed_url.path.rstrip("/") == "":
             continue
 
         # Skip non-page URLs
@@ -110,11 +112,13 @@ def main():
 
     # Load state
     state_path = Path(args.state_file)
+    indexed_urls = set()
     if state_path.exists():
-        state = json.loads(state_path.read_text())
-        indexed_urls = set(state.get("indexed_urls", []))
-    else:
-        indexed_urls = set()
+        try:
+            state = json.loads(state_path.read_text())
+            indexed_urls = set(state.get("indexed_urls", []))
+        except json.JSONDecodeError:
+            logger.warning(f"Failed to decode state file: {state_path}. Starting with empty state.")
 
     # Parse sitemap
     sitemap_path = Path(args.sitemap)

--- a/page-generator/main.py
+++ b/page-generator/main.py
@@ -640,6 +640,8 @@ Options:
   --rebuild-index      Rebuild and re-sort index.html and update 
                        stats_summary.json from all available clue images.
 
+  --submit-indexing    Submit new URLs to Google Indexing API.
+
   --add-nickname       [date] [nickname]
                        Add an alternate accepted answer (nickname/easter egg)
                        to an existing puzzle page. Prompts if not provided.
@@ -690,6 +692,13 @@ Notes:
     regenerate_mode = "--regenerate-facts" in sys.argv
     rebuild_index_mode = "--rebuild-index" in sys.argv
     add_nickname_mode = "--add-nickname" in sys.argv
+    submit_indexing_mode = "--submit-indexing" in sys.argv
+
+    # Handle submit indexing
+    if submit_indexing_mode:
+        from indexing.submit_urls import main as submit_main
+        submit_main()
+        sys.exit(0)
 
     # Handle automation configuration
     if config_mode and AUTOMATION_AVAILABLE:

--- a/tests/fixtures/mock_indexing_response.json
+++ b/tests/fixtures/mock_indexing_response.json
@@ -1,0 +1,9 @@
+{
+  "urlNotificationMetadata": {
+    "url": "https://namethatyankeequiz.com/2026-07-20",
+    "latestUpdate": {
+      "type": "URL_UPDATED",
+      "notifyTime": "2026-07-20T12:00:00Z"
+    }
+  }
+}

--- a/tests/fixtures/mock_sitemap.xml
+++ b/tests/fixtures/mock_sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://namethatyankeequiz.com/</loc>
+    <lastmod>2026-07-20</lastmod>
+  </url>
+  <url>
+    <loc>https://namethatyankeequiz.com/2026-07-19</loc>
+    <lastmod>2026-07-19</lastmod>
+  </url>
+  <url>
+    <loc>https://namethatyankeequiz.com/2026-07-20</loc>
+    <lastmod>2026-07-20</lastmod>
+  </url>
+</urlset>

--- a/tests/unit/page_generator/test_google_indexing.py
+++ b/tests/unit/page_generator/test_google_indexing.py
@@ -1,0 +1,73 @@
+# ABOUTME: Unit tests for Google Indexing API client.
+# ABOUTME: Tests URL submission and error handling using mocked API responses.
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from indexing.google_indexing import GoogleIndexingClient
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures"
+
+
+class TestGoogleIndexingClient:
+    def test_submit_url_success(self):
+        """Test successful URL submission returns metadata."""
+        mock_response = json.loads(
+            (FIXTURE_DIR / "mock_indexing_response.json").read_text()
+        )
+
+        with patch(
+            "indexing.google_indexing.build"
+        ) as mock_build:
+            mock_service = MagicMock()
+            mock_build.return_value = mock_service
+            mock_service.urlNotifications().publish.return_value.execute.return_value = (
+                mock_response
+            )
+
+            client = GoogleIndexingClient.__new__(GoogleIndexingClient)
+            client.service = mock_service
+
+            result = client.submit_url("https://namethatyankeequiz.com/2026-07-20")
+
+            assert result == mock_response
+            mock_service.urlNotifications().publish.assert_called_once()
+
+    def test_submit_url_returns_url(self):
+        """Test that the submitted URL is included in the request."""
+        with patch(
+            "indexing.google_indexing.build"
+        ) as mock_build:
+            mock_service = MagicMock()
+            mock_build.return_value = mock_service
+            mock_service.urlNotifications().publish.return_value.execute.return_value = {}
+
+            client = GoogleIndexingClient.__new__(GoogleIndexingClient)
+            client.service = mock_service
+
+            url = "https://namethatyankeequiz.com/2026-07-20"
+            client.submit_url(url)
+
+            call_args = mock_service.urlNotifications().publish.call_args
+            body = call_args[1]["body"] if "body" in call_args[1] else call_args[0][0]
+            assert body["url"] == url
+            assert body["type"] == "URL_UPDATED"
+
+    def test_submit_url_handles_api_error(self):
+        """Test that API errors are caught and re-raised with context."""
+        with patch(
+            "indexing.google_indexing.build"
+        ) as mock_build:
+            mock_service = MagicMock()
+            mock_build.return_value = mock_service
+            mock_service.urlNotifications().publish.return_value.execute.side_effect = Exception(
+                "Quota exceeded"
+            )
+
+            client = GoogleIndexingClient.__new__(GoogleIndexingClient)
+            client.service = mock_service
+
+            with pytest.raises(Exception, match="Quota exceeded"):
+                client.submit_url("https://namethatyankeequiz.com/2026-07-20")

--- a/tests/unit/page_generator/test_submit_urls.py
+++ b/tests/unit/page_generator/test_submit_urls.py
@@ -17,7 +17,7 @@ class TestParseSitemap:
         urls = parse_sitemap(sitemap_path)
 
         assert len(urls) == 3
-        assert "https://namethatyankeequiz.com/" in urls
+        assert "https://namethatyankeequiz.com/" in urls  # lgtm[py/incomplete-url-substring-sanitization]
         assert "https://namethatyankeequiz.com/2026-07-19" in urls
         assert "https://namethatyankeequiz.com/2026-07-20" in urls
 

--- a/tests/unit/page_generator/test_submit_urls.py
+++ b/tests/unit/page_generator/test_submit_urls.py
@@ -1,0 +1,68 @@
+# ABOUTME: Tests for the URL submission script.
+# ABOUTME: Validates sitemap parsing and URL filtering logic.
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from indexing.submit_urls import parse_sitemap, filter_new_urls
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures"
+
+
+class TestParseSitemap:
+    def test_parses_urls_from_sitemap(self):
+        """Test that URLs are extracted from sitemap XML."""
+        sitemap_path = FIXTURE_DIR / "mock_sitemap.xml"
+        urls = parse_sitemap(sitemap_path)
+
+        assert len(urls) == 3
+        assert "https://namethatyankeequiz.com/" in urls
+        assert "https://namethatyankeequiz.com/2026-07-19" in urls
+        assert "https://namethatyankeequiz.com/2026-07-20" in urls
+
+    def test_handles_missing_sitemap(self):
+        """Test that missing sitemap raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError):
+            parse_sitemap(Path("/nonexistent/sitemap.xml"))
+
+
+class TestFilterNewUrls:
+    def test_filters_already_indexed_urls(self):
+        """Test that previously indexed URLs are excluded."""
+        all_urls = [
+            "https://namethatyankeequiz.com/",
+            "https://namethatyankeequiz.com/2026-07-19",
+            "https://namethatyankeequiz.com/2026-07-20",
+        ]
+        indexed = {"https://namethatyankeequiz.com/", "https://namethatyankeequiz.com/2026-07-19"}
+
+        new_urls = filter_new_urls(all_urls, indexed)
+
+        assert len(new_urls) == 1
+        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls
+
+    def test_excludes_index_html(self):
+        """Test that index.html pages are excluded."""
+        all_urls = [
+            "https://namethatyankeequiz.com/",
+            "https://namethatyankeequiz.com/2026-07-20",
+        ]
+
+        new_urls = filter_new_urls(all_urls, set())
+
+        assert len(new_urls) == 1
+        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls
+
+    def test_excludes_non_page_urls(self):
+        """Test that non-page URLs (images, css, etc.) are excluded."""
+        all_urls = [
+            "https://namethatyankeequiz.com/2026-07-20",
+            "https://namethatyankeequiz.com/images/clue-2026-07-20.webp",
+            "https://namethatyankeequiz.com/style.css",
+        ]
+
+        new_urls = filter_new_urls(all_urls, set())
+
+        assert len(new_urls) == 1
+        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls

--- a/tests/unit/page_generator/test_submit_urls.py
+++ b/tests/unit/page_generator/test_submit_urls.py
@@ -17,9 +17,12 @@ class TestParseSitemap:
         urls = parse_sitemap(sitemap_path)
 
         assert len(urls) == 3
-        assert "https://namethatyankeequiz.com/" in urls  # lgtm[py/incomplete-url-substring-sanitization]
-        assert "https://namethatyankeequiz.com/2026-07-19" in urls
-        assert "https://namethatyankeequiz.com/2026-07-20" in urls
+        expected_urls = {
+            "https://namethatyankeequiz.com/",
+            "https://namethatyankeequiz.com/2026-07-19",
+            "https://namethatyankeequiz.com/2026-07-20",
+        }
+        assert expected_urls.issubset(set(urls))
 
     def test_handles_missing_sitemap(self):
         """Test that missing sitemap raises FileNotFoundError."""
@@ -40,7 +43,7 @@ class TestFilterNewUrls:
         new_urls = filter_new_urls(all_urls, indexed)
 
         assert len(new_urls) == 1
-        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls
+        assert new_urls[0] == "https://namethatyankeequiz.com/2026-07-20"
 
     def test_excludes_index_html(self):
         """Test that index.html pages are excluded."""
@@ -52,7 +55,7 @@ class TestFilterNewUrls:
         new_urls = filter_new_urls(all_urls, set())
 
         assert len(new_urls) == 1
-        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls
+        assert new_urls[0] == "https://namethatyankeequiz.com/2026-07-20"
 
     def test_excludes_non_page_urls(self):
         """Test that non-page URLs (images, css, etc.) are excluded."""
@@ -65,4 +68,4 @@ class TestFilterNewUrls:
         new_urls = filter_new_urls(all_urls, set())
 
         assert len(new_urls) == 1
-        assert "https://namethatyankeequiz.com/2026-07-20" in new_urls
+        assert new_urls[0] == "https://namethatyankeequiz.com/2026-07-20"


### PR DESCRIPTION
## Summary
Adds Google Indexing API integration to automatically submit new answer pages for indexing after each deploy.

### What's included:
- **page-generator/indexing/google_indexing.py** — GoogleIndexingClient class with OAuth2 auth, URL submission, and error handling
- **page-generator/indexing/submit_urls.py** — CLI script that parses sitemap, filters new URLs, tracks state to avoid re-submission, and supports dry-run mode
- **page-generator/main.py** — Added `--submit-indexing` CLI flag
- **.github/workflows/deploy.yml** — Non-blocking indexing step runs after deploy (credentials via secret, state persistence via artifact)
- **README_AUTOMATION.md** — Updated with Indexing API setup instructions

### How it works:
After each deploy, the workflow downloads the built site, parses the sitemap, compares against previously submitted URLs, and submits new ones to the Indexing API. All steps use `continue-on-error: true` so indexing failures never block deployment.

### Setup required:
1. Add `GOOGLE_INDEXING_CREDENTIALS` secret to GitHub repo (GCP service account JSON)
2. Add service account email as **Owner** in Google Search Console

### Testing:
- 8/8 unit tests passing
- Includes mock fixtures for API responses and sitemap parsing