### PR TITLE
feat: submit sitemap to Search Console after deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,6 +133,11 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
       - name: Submit sitemap to Search Console
         if: success()
         continue-on-error: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -143,5 +143,6 @@ jobs:
           pip install google-api-python-client google-auth
           PYTHONPATH=./page-generator python -m search_console.submit_sitemap \
             --credentials /tmp/search-console-creds.json
+          rm -f /tmp/search-console-creds.json
 
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -140,6 +140,7 @@ jobs:
           CREDS: ${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}
         run: |
           printf "%s" "$CREDS" > /tmp/search-console-creds.json
+          # Install only the packages needed for sitemap submit (subset of requirements.txt)
           pip install google-api-python-client google-auth
           PYTHONPATH=./page-generator python -m search_console.submit_sitemap \
             --credentials /tmp/search-console-creds.json

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -133,4 +133,15 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
+      - name: Submit sitemap to Search Console
+        if: success()
+        continue-on-error: true
+        env:
+          CREDS: ${{ secrets.GOOGLE_INDEXING_CREDENTIALS }}
+        run: |
+          printf "%s" "$CREDS" > /tmp/search-console-creds.json
+          pip install google-api-python-client google-auth
+          PYTHONPATH=./page-generator python -m search_console.submit_sitemap \
+            --credentials /tmp/search-console-creds.json
+
 

--- a/README_AUTOMATION.md
+++ b/README_AUTOMATION.md
@@ -158,6 +158,31 @@ The automation is fully backward compatible:
 - No breaking changes to existing API
 - Automation as opt-in feature
 
+## Google Search Console Sitemap Integration
+
+After each deploy, the workflow automatically resubmits the sitemap to Google
+Search Console, prompting Google to re-read it and discover new pages.
+
+### Setup Requirements
+
+1. **Google Cloud Service Account:**
+   - Use an existing service account or create one at https://console.cloud.google.com/iam-admin/serviceaccounts
+   - Enable "Search Console API" in the service account's API list
+   - Download the JSON key file
+
+2. **Google Search Console:**
+   - Add the service account email as an **Owner** in Search Console
+   - Go to Settings > Users and permissions > Add user
+
+3. **GitHub Secrets:**
+   - Add `GOOGLE_INDEXING_CREDENTIALS` with the contents of the JSON key file
+
+### How It Works
+
+1. After a successful deploy, the workflow runs `search_console/submit_sitemap.py`
+2. The script calls `sitemaps.submit` via the Search Console API
+3. Google re-reads the sitemap and indexes any new pages
+
 ## Troubleshooting
 
 ### Common Issues

--- a/page-generator/search_console/__init__.py
+++ b/page-generator/search_console/__init__.py
@@ -1,0 +1,2 @@
+# ABOUTME: Initialization for the search_console package.
+# ABOUTME: Google Search Console API integration for sitemap management.

--- a/page-generator/search_console/submit_sitemap.py
+++ b/page-generator/search_console/submit_sitemap.py
@@ -1,0 +1,51 @@
+# ABOUTME: Submit sitemap to Google Search Console via API.
+# ABOUTME: Triggers Google to re-read the sitemap and discover new pages.
+"""Submit sitemap to Google Search Console.
+
+Usage:
+    from search_console.submit_sitemap import submit_sitemap
+    submit_sitemap("creds.json", "https://example.com/", "https://example.com/sitemap.xml")
+"""
+
+import logging
+
+from google.oauth2 import service_account
+from googleapiclient.discovery import build
+
+logger = logging.getLogger(__name__)
+
+SCOPES = ["https://www.googleapis.com/auth/webmasters"]
+
+
+def submit_sitemap(
+    credentials_file: str,
+    site_url: str = "https://namethatyankeequiz.com/",
+    sitemap_url: str = "https://namethatyankeequiz.com/sitemap.xml",
+) -> bool:
+    """Submit a sitemap URL to Google Search Console.
+
+    Args:
+        credentials_file: Path to GCP service account JSON key file.
+        site_url: The property URL as defined in Search Console.
+        sitemap_url: The full URL of the sitemap to submit.
+
+    Returns:
+        True if submission succeeded, False otherwise.
+    """
+    try:
+        credentials = service_account.Credentials.from_service_account_file(
+            credentials_file, scopes=SCOPES
+        )
+        service = build("webmasters", "v3", credentials=credentials)
+
+        logger.info(f"Submitting sitemap to Search Console: {sitemap_url}")
+        service.sitemaps().submit(
+            siteUrl=site_url,
+            feedpath=sitemap_url,
+        ).execute()
+
+        logger.info("Sitemap submitted successfully.")
+        return True
+    except Exception as e:
+        logger.error(f"Failed to submit sitemap: {e}")
+        return False

--- a/page-generator/search_console/submit_sitemap.py
+++ b/page-generator/search_console/submit_sitemap.py
@@ -53,6 +53,12 @@ def submit_sitemap(
 
 if __name__ == "__main__":
     import argparse
+    import os
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+    )
 
     parser = argparse.ArgumentParser(
         description="Submit sitemap to Google Search Console"
@@ -64,12 +70,12 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--site-url",
-        default="https://namethatyankeequiz.com/",
+        default=os.getenv("SITE_URL", "https://namethatyankeequiz.com/"),
         help="Property URL in Search Console",
     )
     parser.add_argument(
         "--sitemap-url",
-        default="https://namethatyankeequiz.com/sitemap.xml",
+        default=os.getenv("SITEMAP_URL", "https://namethatyankeequiz.com/sitemap.xml"),
         help="Full URL of the sitemap to submit",
     )
     args = parser.parse_args()

--- a/page-generator/search_console/submit_sitemap.py
+++ b/page-generator/search_console/submit_sitemap.py
@@ -49,3 +49,30 @@ def submit_sitemap(
     except Exception as e:
         logger.error(f"Failed to submit sitemap: {e}")
         return False
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Submit sitemap to Google Search Console"
+    )
+    parser.add_argument(
+        "--credentials",
+        required=True,
+        help="Path to GCP service account credentials JSON",
+    )
+    parser.add_argument(
+        "--site-url",
+        default="https://namethatyankeequiz.com/",
+        help="Property URL in Search Console",
+    )
+    parser.add_argument(
+        "--sitemap-url",
+        default="https://namethatyankeequiz.com/sitemap.xml",
+        help="Full URL of the sitemap to submit",
+    )
+    args = parser.parse_args()
+
+    success = submit_sitemap(args.credentials, args.site_url, args.sitemap_url)
+    raise SystemExit(0 if success else 1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,8 @@ dataclasses-json==0.5.7
 distro==1.9.0
 google-ai-generativelanguage==0.6.15
 google-api-core==2.25.2
+google-api-python-client==2.193.0
+google-auth==2.49.1
 google-genai==1.69.0
 google-generativeai==0.8.6
 googleapis-common-protos==1.72.0

--- a/tests/unit/page_generator/test_submit_sitemap.py
+++ b/tests/unit/page_generator/test_submit_sitemap.py
@@ -1,0 +1,58 @@
+# ABOUTME: Unit tests for Search Console sitemap submission script.
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures"
+
+
+class TestSubmitSitemap:
+    def test_submit_calls_api(self):
+        mock_service = MagicMock()
+        mock_service.sitemaps.return_value.submit.return_value.execute.return_value = {}
+        mock_creds = MagicMock()
+
+        with patch(
+            "search_console.submit_sitemap.service_account.Credentials.from_service_account_file",
+            return_value=mock_creds,
+        ), patch(
+            "search_console.submit_sitemap.build", return_value=mock_service
+        ):
+            from search_console.submit_sitemap import submit_sitemap
+
+            result = submit_sitemap(
+                credentials_file="fake_creds.json",
+                site_url="https://example.com/",
+                sitemap_url="https://example.com/sitemap.xml",
+            )
+
+            mock_service.sitemaps.return_value.submit.assert_called_once_with(
+                siteUrl="https://example.com/",
+                feedpath="https://example.com/sitemap.xml",
+            )
+            mock_service.sitemaps.return_value.submit.return_value.execute.assert_called_once()
+            assert result is True
+
+    def test_submit_handles_api_error(self):
+        mock_service = MagicMock()
+        mock_service.sitemaps.return_value.submit.return_value.execute.side_effect = Exception("API error")
+        mock_creds = MagicMock()
+
+        with patch(
+            "search_console.submit_sitemap.service_account.Credentials.from_service_account_file",
+            return_value=mock_creds,
+        ), patch(
+            "search_console.submit_sitemap.build", return_value=mock_service
+        ):
+            from search_console.submit_sitemap import submit_sitemap
+
+            result = submit_sitemap(
+                credentials_file="fake_creds.json",
+                site_url="https://example.com/",
+                sitemap_url="https://example.com/sitemap.xml",
+            )
+
+            assert result is False

--- a/tests/unit/page_generator/test_submit_sitemap.py
+++ b/tests/unit/page_generator/test_submit_sitemap.py
@@ -1,12 +1,6 @@
 # ABOUTME: Unit tests for Search Console sitemap submission script.
 
-import json
-from pathlib import Path
 from unittest.mock import MagicMock, patch
-
-import pytest
-
-FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures"
 
 
 class TestSubmitSitemap:

--- a/tests/unit/page_generator/test_submit_sitemap.py
+++ b/tests/unit/page_generator/test_submit_sitemap.py
@@ -1,4 +1,5 @@
 # ABOUTME: Unit tests for Search Console sitemap submission script.
+# ABOUTME: Verifies API calls are invoked and error handling behaves as expected.
 
 from unittest.mock import MagicMock, patch
 


### PR DESCRIPTION
Automatically resubmit the sitemap to Google Search Console after each deploy, prompting Google to re-read it and discover new answer pages.

**What changed:**
- New  — calls  API
- Deploy workflow step runs after GitHub Pages deploy (with )
- Re-added  and  dependencies
- Unit tests for the submit script
- Documentation in README_AUTOMATION.md

**Setup required:**
- Enable Search Console API in GCP project
- Verify service account email is Owner in Search Console
-  secret already exists