### PR TITLE
chore: bump js-yaml to 4.3.1 for CVE-2026-59870

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6861,9 +6861,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fast-uri": "3.1.5",
     "ip-address": "10.4.0",
     "hono": "4.13.0",
+    "js-yaml": "4.3.1",
     "morgan": "1.11.0",
     "@hono/node-server": "2.0.11",
     "@opentelemetry/core": "2.10.0"


### PR DESCRIPTION
## Summary
Fixes the newly published GHSA-5p4m-2wfm-xmqj (CVE-2026-59870, high) — quadratic CPU consumption in `!!omap` resolution. Affects js-yaml `>= 4.0.0, < 4.3.1`; fixed in 4.3.1.

Transitive via firebase-tools → js-yaml (`^4.2.0`) and → exegesis → @apidevtools/json-schema-ref-parser (`^4.1.0`). Added override `"js-yaml": "4.3.1"` (both parent ranges already allow it).

## Verification
- `npm audit` → 0 vulnerabilities
- `npm ls js-yaml` → 4.3.1 overridden
- `bash run_tests.sh` → 195 unit + 5 automation + 61 E2E + 99 vitest all pass